### PR TITLE
Side effects

### DIFF
--- a/core/src/main/scala/endless/core/interpret/EntityT.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityT.scala
@@ -5,7 +5,8 @@ import cats.data.{Chain, NonEmptyChain}
 import cats.syntax.applicative._
 import cats.syntax.either._
 import cats.syntax.flatMap._
-import cats.{Applicative, Monad}
+import cats.syntax.functor._
+import cats.{Applicative, Functor, Monad}
 import endless.core.data.EventsFolder
 import endless.core.data.Folded
 
@@ -46,6 +47,9 @@ object EntityT extends EntityRunFunctions {
   def purr[F[_]: Applicative, S, E, A](a: A): EntityT[F, S, E, A] = new EntityT((_, events) =>
     pure(a)(events)
   )
+
+  def liftF[F[_]: Functor, S, E, A](fa: F[A]): EntityT[F, S, E, A] =
+    new EntityT((_, events) => fa.map(a => (events, a).asRight))
 
   def reader[F[_]: Monad, S, E]: EntityT[F, S, E, S] = new EntityT(read[F, S, E])
 

--- a/core/src/main/scala/endless/core/interpret/StateReaderT.scala
+++ b/core/src/main/scala/endless/core/interpret/StateReaderT.scala
@@ -1,0 +1,14 @@
+package endless.core.interpret
+
+import cats.Applicative
+import cats.data.ReaderT
+import endless.core.typeclass.entity.StateReader
+
+object StateReaderT {
+  trait StateReaderLift[G[_], F[_], S] extends StateReader[G, S]
+
+  implicit def instance[F[_]: Applicative, S]: StateReaderLift[ReaderT[F, S, *], F, S] =
+    new StateReaderLift[ReaderT[F, S, *], F, S] {
+      override def read: ReaderT[F, S, S] = ReaderT.ask
+    }
+}

--- a/core/src/main/scala/endless/core/typeclass/effect/Effector.scala
+++ b/core/src/main/scala/endless/core/typeclass/effect/Effector.scala
@@ -1,5 +1,16 @@
 package endless.core.typeclass.effect
 
+import cats.{Applicative, Id}
+import endless.core.typeclass.entity.StateReader
+
 trait Effector[F[_]] {
   def afterPersist: F[Unit]
+}
+
+object Effector {
+  def unit[F[_]: Applicative, S]: StateReader[F, S] => Effector[F] = UnitEffector(_)
+  private final case class UnitEffector[F[_]: Applicative, S](reader: StateReader[F, S])
+      extends Effector[F] {
+    override def afterPersist: F[Unit] = Applicative[F].unit
+  }
 }

--- a/core/src/main/scala/endless/core/typeclass/effect/Effector.scala
+++ b/core/src/main/scala/endless/core/typeclass/effect/Effector.scala
@@ -1,0 +1,5 @@
+package endless.core.typeclass.effect
+
+trait Effector[F[_]] {
+  def afterPersist: F[Unit]
+}

--- a/example/src/main/scala/endless/example/data/Booking.scala
+++ b/example/src/main/scala/endless/example/data/Booking.scala
@@ -1,7 +1,7 @@
 package endless.example.data
 
 import endless.example.data.Booking._
-import cats.Eq
+import cats.{Eq, Show}
 
 import java.util.UUID
 
@@ -14,8 +14,12 @@ final case class Booking(
 
 object Booking {
   final case class BookingID(id: UUID) extends AnyVal
+  object BookingID {
+    implicit val show: Show[BookingID] = Show.fromToString
+  }
   final case class LatLon(lat: Double, lon: Double)
   object LatLon {
     implicit val eq: Eq[LatLon] = Eq.fromUniversalEquals
   }
+  implicit val show: Show[Booking] = Show.fromToString
 }

--- a/example/src/main/scala/endless/example/logic/BookingEffector.scala
+++ b/example/src/main/scala/endless/example/logic/BookingEffector.scala
@@ -1,0 +1,16 @@
+package endless.example.logic
+
+import cats.Monad
+import endless.core.typeclass.effect.Effector
+import endless.core.typeclass.entity.StateReader
+import endless.example.data.Booking
+import org.typelevel.log4cats.Logger
+import cats.syntax.flatMap._
+import cats.syntax.show._
+
+final case class BookingEffector[F[_]: Logger: Monad](reader: StateReader[F, Option[Booking]])
+    extends Effector[F] {
+  import reader._
+  override def afterPersist: F[Unit] =
+    read >>= (booking => Logger[F].info(show"State is now $booking"))
+}

--- a/runtime/src/main/scala/endless/runtime/akka/Deployer.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/Deployer.scala
@@ -6,7 +6,7 @@ import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityTypeKey}
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior}
 import akka.util.Timeout
-import cats.{Functor, Monad}
+import cats.{Functor, Monad, ~>}
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Dispatcher
 import cats.tagless.FunctorK
@@ -22,7 +22,6 @@ import cats.syntax.show._
 import endless.core.interpret.RepositoryT
 import endless.core.typeclass.effect.Effector
 import org.typelevel.log4cats.Logger
-
 import cats.data.ReaderT
 
 trait Deployer {

--- a/runtime/src/main/scala/endless/runtime/akka/Deployer.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/Deployer.scala
@@ -3,29 +3,29 @@ package endless.runtime.akka
 import akka.actor.typed.{ActorRef, ActorSystem}
 import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityTypeKey}
-import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.{PersistenceId, RecoveryCompleted, RecoveryFailed}
 import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior}
 import akka.util.Timeout
-import cats.{Functor, Monad, ~>}
+import cats.data.ReaderT
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Dispatcher
+import cats.syntax.applicative._
+import cats.syntax.flatMap._
+import cats.syntax.show._
 import cats.tagless.FunctorK
 import endless.core.interpret._
+import endless.core.typeclass.effect.Effector
 import endless.core.typeclass.entity._
 import endless.core.typeclass.event.EventApplier
-import endless.core.typeclass.protocol.{CommandProtocol, EntityIDEncoder}
+import endless.core.typeclass.protocol.{CommandProtocol, CommandRouter, EntityIDEncoder}
 import endless.runtime.akka.data._
-import ShardingCommandRouter._
-import cats.syntax.flatMap._
-import cats.syntax.applicative._
-import cats.syntax.show._
-import endless.core.interpret.RepositoryT
-import endless.core.typeclass.effect.Effector
 import org.typelevel.log4cats.Logger
-import cats.data.ReaderT
 
 trait Deployer {
-  def deployEntity[F[_]: Monad: Logger, S, E, ID, Alg[_[_]]: FunctorK, RepositoryAlg[_[_]]](
+
+  def deployEntity[F[_]: Async: Logger, S, E, ID, Alg[_[_]]: FunctorK, RepositoryAlg[_[
+      _
+  ]]](
       createEntity: Entity[EntityT[F, S, E, *], S, E] => Alg[EntityT[F, S, E, *]],
       createRepository: Repository[F, ID, Alg] => RepositoryAlg[F],
       createEffector: StateReader[ReaderT[F, S, *], S] => Effector[ReaderT[F, S, *]],
@@ -42,76 +42,107 @@ trait Deployer {
       idEncoder: EntityIDEncoder[ID],
       commandProtocol: CommandProtocol[Alg],
       eventApplier: EventApplier[S, E],
-      askTimeout: Timeout,
-      F: Async[F]
+      askTimeout: Timeout
   ): Resource[F, (RepositoryAlg[F], ActorRef[ShardingEnvelope[Command]])] =
-    Dispatcher[F].map { implicit dispatcher =>
-      implicit val interpretedEntityAlg: Alg[EntityT[F, S, E, *]] = createEntity(
-        EntityT.instance
-      )
-      implicit val interpretedEffector: ReaderT[F, S, Unit] =
-        createEffector(StateReaderT.instance).afterPersist
-      val entityTypeKey = EntityTypeKey[Command](nameProvider())
-      val akkaEntity = akka.cluster.sharding.typed.scaladsl.Entity(
-        EntityTypeKey[Command](nameProvider())
-      ) { context =>
-        customizeBehavior(
-          EventSourcedBehavior.withEnforcedReplies[Command, E, S](
-            PersistenceId(entityTypeKey.name, context.entityId),
-            emptyState,
-            commandHandler = handleCommand[RepositoryAlg, Alg, ID, E, S, F],
-            eventHandler = handleEvent[E, S, F]
-          )
-        )
-      }
-      (createRepository(RepositoryT.apply[F, S, E, ID, Alg]), sharding.init(akkaEntity))
-    }
-
-  private def handleEvent[E, S, F[_]: Logger](state: S, event: E)(implicit
-      eventApplier: EventApplier[S, E],
-      dispatcher: Dispatcher[F]
-  ) = eventApplier.apply(state, event) match {
-    case Left(error) =>
-      dispatcher.unsafeRunSync(Logger[F].warn(error))
-      throw new EventApplierException(error)
-    case Right(newState) => newState
-  }
-
-  private def handleCommand[RepositoryAlg[_[_]], Alg[_[_]]: FunctorK, ID, E, S, F[
-      _
-  ]: Monad: Logger](state: S, command: Command)(implicit
-      nameProvider: EntityNameProvider[ID],
-      commandProtocol: CommandProtocol[Alg],
-      eventApplier: EventApplier[S, E],
-      dispatcher: Dispatcher[F],
-      interpretedEntity: Alg[EntityT[F, S, E, *]],
-      interpretedEffector: ReaderT[F, S, Unit],
-      askTimeout: Timeout,
-      sharding: ClusterSharding,
-      actorSystem: ActorSystem[_],
-      idEncoder: EntityIDEncoder[ID],
-      F: Async[F]
-  ) = {
-    val incomingCommand =
-      commandProtocol.server[EntityT[F, S, E, *]].decode(command.payload)
-    val effect = Logger[F].debug(
-      show"Handling command for ${nameProvider()} entity ${command.id}"
-    ) >> RepositoryT.apply
-      .runCommand(state, incomingCommand)
-      .flatMap {
-        case Left(error) =>
-          Logger[F].warn(error) >> Effect.unhandled[E, S].thenNoReply().pure
-        case Right((events, reply)) =>
-          Effect
-            .persist(events.toList)
-            .thenRun((state: S) => dispatcher.unsafeRunSync(interpretedEffector.run(state)))
-            .thenReply(command.replyTo) { _: S =>
-              Reply(incomingCommand.replyEncoder.encode(reply))
-            }
-            .pure
-      }
-    dispatcher.unsafeRunSync(effect)
-  }
+    new DeployEntity(
+      createEntity,
+      createRepository,
+      createEffector,
+      emptyState,
+      customizeBehavior
+    ).apply
 
   final class EventApplierException(error: String) extends RuntimeException(error)
+
+  private class DeployEntity[F[_]: Async: Logger, S, E, ID, Alg[_[_]]: FunctorK, RepositoryAlg[_[
+      _
+  ]]](
+      createEntity: Entity[EntityT[F, S, E, *], S, E] => Alg[EntityT[F, S, E, *]],
+      createRepository: Repository[F, ID, Alg] => RepositoryAlg[F],
+      createEffector: StateReader[ReaderT[F, S, *], S] => Effector[ReaderT[F, S, *]],
+      emptyState: S,
+      customizeBehavior: EventSourcedBehavior[Command, E, S] => EventSourcedBehavior[Command, E, S]
+  )(implicit
+      sharding: ClusterSharding,
+      actorSystem: ActorSystem[_],
+      nameProvider: EntityNameProvider[ID],
+      idEncoder: EntityIDEncoder[ID],
+      commandProtocol: CommandProtocol[Alg],
+      eventApplier: EventApplier[S, E],
+      askTimeout: Timeout
+  ) {
+    private implicit val interpretedEntityAlg: Alg[EntityT[F, S, E, *]] = createEntity(
+      EntityT.instance
+    )
+    private implicit val interpretedEffector: ReaderT[F, S, Unit] = createEffector(
+      StateReaderT.instance
+    ).afterPersist
+    private val entityTypeKey = EntityTypeKey[Command](nameProvider())
+    private implicit val commandRouter: CommandRouter[F, ID] = ShardingCommandRouter.apply
+
+    def apply: Resource[F, (RepositoryAlg[F], ActorRef[ShardingEnvelope[Command]])] =
+      Dispatcher[F].map { implicit dispatcher =>
+        val akkaEntity = akka.cluster.sharding.typed.scaladsl.Entity(
+          EntityTypeKey[Command](nameProvider())
+        ) { context =>
+          customizeBehavior(
+            EventSourcedBehavior
+              .withEnforcedReplies[Command, E, S](
+                PersistenceId(entityTypeKey.name, context.entityId),
+                emptyState,
+                commandHandler = handleCommand,
+                eventHandler = handleEvent
+              )
+              .receiveSignal {
+                case (state, RecoveryCompleted) =>
+                  dispatcher.unsafeRunSync(
+                    Logger[F].info(
+                      show"Recovery of ${nameProvider()} entity ${context.entityId} completed"
+                    ) >> interpretedEffector.run(state)
+                  )
+                case (_, RecoveryFailed(failure)) =>
+                  dispatcher.unsafeRunSync(
+                    Logger[F].warn(
+                      show"Recovery of ${nameProvider()} entity ${context.entityId} failed with error ${failure.getMessage}"
+                    )
+                  )
+              }
+          )
+        }
+        (createRepository(RepositoryT.apply[F, S, E, ID, Alg]), sharding.init(akkaEntity))
+      }
+
+    private def handleEvent(state: S, event: E)(implicit
+        eventApplier: EventApplier[S, E],
+        dispatcher: Dispatcher[F]
+    ) = eventApplier.apply(state, event) match {
+      case Left(error) =>
+        dispatcher.unsafeRunSync(Logger[F].warn(error))
+        throw new EventApplierException(error)
+      case Right(newState) => newState
+    }
+
+    private def handleCommand(state: S, command: Command)(implicit dispatcher: Dispatcher[F]) = {
+      val incomingCommand =
+        commandProtocol.server[EntityT[F, S, E, *]].decode(command.payload)
+      val effect = Logger[F].debug(
+        show"Handling command for ${nameProvider()} entity ${command.id}"
+      ) >> RepositoryT.apply
+        .runCommand(state, incomingCommand)
+        .flatMap {
+          case Left(error) =>
+            Logger[F].warn(error) >> Effect.unhandled[E, S].thenNoReply().pure
+          case Right((events, reply)) =>
+            Effect
+              .persist(events.toList)
+              .thenRun((state: S) => dispatcher.unsafeRunSync(interpretedEffector.run(state)))
+              .thenReply(command.replyTo) { _: S =>
+                Reply(incomingCommand.replyEncoder.encode(reply))
+              }
+              .pure
+        }
+      dispatcher.unsafeRunSync(effect)
+    }
+  }
+
 }

--- a/runtime/src/main/scala/endless/runtime/akka/LoggerLiftingHelpers.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/LoggerLiftingHelpers.scala
@@ -1,0 +1,19 @@
+package endless.runtime.akka
+
+import cats.data.ReaderT
+import cats.{Functor, ~>}
+import endless.core.interpret.EntityT
+import org.typelevel.log4cats.Logger
+
+trait LoggerLiftingHelpers {
+  implicit def loggerForEntityT[F[_]: Functor, S, E](implicit
+      logger: Logger[F]
+  ): Logger[EntityT[F, S, E, *]] = logger.mapK(new (F ~> EntityT[F, S, E, *]) {
+    override def apply[A](fa: F[A]): EntityT[F, S, E, A] = EntityT.liftF[F, S, E, A](fa)
+  })
+
+  implicit def loggerForReaderT[F[_], S](implicit logger: Logger[F]): Logger[ReaderT[F, S, *]] =
+    logger.mapK(new (F ~> ReaderT[F, S, *]) {
+      override def apply[A](fa: F[A]): ReaderT[F, S, A] = ReaderT.liftF(fa)
+    })
+}

--- a/runtime/src/main/scala/endless/runtime/akka/syntax/package.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/syntax/package.scala
@@ -1,5 +1,5 @@
 package endless.runtime.akka
 
 package object syntax {
-  object deploy extends Deployer
+  object deploy extends Deployer with LoggerLiftingHelpers
 }


### PR DESCRIPTION
Added support for side-effects guaranteed to run after persistence via a separate `Effector` typeclass. A constructor for such an effector instance needs to be provided in the `deployEntity` call (along with entity & repository constructor, empty state, commandProtocol, etc.). A default `Effector.unit` is provided for entities which do not have side-effects.

Such effector instances simply need to implement `def afterPersist: F[Unit]` and are provided a `StateReader[F, S]` upon construction, which is the reader typeclass and allows to retrieve the entity state from `F`. Side-effects indeed typically depend on entity state (for instance the list of pending asynchronous operations such as writes to kafka, in-flight requests, etc.). The effector is invoked within the `thenRun` in Akka entity DSL as well as upon successful recovery.

  