### PR TITLE
Introduce endless-protobuf-helpers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -70,6 +70,21 @@ lazy val scodecHelpers = (project in file("scodec"))
   .settings(libraryDependencies ++= scodecCore ++ mUnit.map(_ % Test))
   .settings(name := "endless-scodec-helpers")
 
+lazy val protobufHelpers = (project in file("protobuf"))
+  .dependsOn(core)
+  .settings(commonSettings: _*)
+  .settings(libraryDependencies ++= mUnit.map(_ % Test))
+  .settings(name := "endless-protobuf-helpers")
+  .settings(
+    Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
+    ),
+    Test / PB.targets := Seq(
+      scalapb.gen() -> (Test / sourceManaged).value / "scalapb"
+    )
+  )
+
 lazy val example = (project in file("example"))
   .dependsOn(core, runtime, circeHelpers)
   .settings(commonSettings: _*)
@@ -131,7 +146,7 @@ lazy val documentation = (project in file("documentation"))
 
 lazy val root = project
   .in(file("."))
-  .aggregate(core, runtime, circeHelpers, scodecHelpers, example)
+  .aggregate(core, runtime, circeHelpers, scodecHelpers, protobufHelpers, example)
   .dependsOn(example)
   .settings(Compile / mainClass := (example / Compile / mainClass).value)
   .settings(commonSettings: _*)

--- a/circe/src/test/scala/endless/circe/CirceCommandProtocolSuite.scala
+++ b/circe/src/test/scala/endless/circe/CirceCommandProtocolSuite.scala
@@ -18,11 +18,11 @@ class CirceCommandProtocolSuite extends munit.ScalaCheckSuite {
   }
 
   val protocol = new CirceCommandProtocol[DummyAlg] {
-    def server[F[_]]: Decoder[IncomingCommand[F, DummyAlg]] = CirceDecoder(
-      implicitly[io.circe.Decoder[DummyCommand]].map { case DummyCommand(x, y) =>
+    def server[F[_]]: Decoder[IncomingCommand[F, DummyAlg]] =
+      CirceDecoder[DummyCommand].map { case DummyCommand(x, y) =>
         incomingCommand[F, Boolean](_.dummy(x, y))
       }
-    )
+
     def client: DummyAlg[OutgoingCommand[*]] = (x: Int, y: String) =>
       outgoingCommand[DummyCommand, Boolean](DummyCommand(x, y))
   }

--- a/core/src/main/scala/endless/core/protocol/Decoder.scala
+++ b/core/src/main/scala/endless/core/protocol/Decoder.scala
@@ -13,4 +13,7 @@ trait Decoder[+A] {
     *   value
     */
   def decode(payload: Array[Byte]): A
+
+  /** Converts this decoder to a Decoder[B] using the supplied A => B */
+  def map[B](f: A => B): Decoder[B] = (payload: Array[Byte]) => f(decode(payload))
 }

--- a/core/src/main/scala/endless/core/protocol/Encoder.scala
+++ b/core/src/main/scala/endless/core/protocol/Encoder.scala
@@ -13,4 +13,7 @@ trait Encoder[-A] {
     *   corresponding byte array
     */
   def encode(a: A): Array[Byte]
+
+  /** Converts this encoder to a `Encoder[B]` using the supplied B => A */
+  def contramap[B](f: B => A): Encoder[B] = (b: B) => encode(f(b))
 }

--- a/documentation/src/main/paradox/protocol.md
+++ b/documentation/src/main/paradox/protocol.md
@@ -15,7 +15,7 @@ In other words, `client` materializes algebra invocations into concrete serializ
 
 @@@ note { .info title="Explicit or implicit representations" }
 `CommandProtocol` is the entry point for implementations to map algebra entries to concrete commands and replies. We tend to prefer explicit materialization for migration safety but nothing prevents protocol implementers to opt for automatic serialization via macros. 
-We provide helpers for definition of binary protocols in `endless-scodec-helpers` and JSON protocols in `endless-circe-helpers`.     
+We provide helpers for definition of binary protocols in `endless-protobuf-helpers` as well as `endless-scodec-helpers` and JSON protocols in `endless-circe-helpers`.     
 @@@
 
 @@@ note { .tip title="Testing" }

--- a/protobuf/src/main/scala/endless/protobuf/ProtobufCommandProtocol.scala
+++ b/protobuf/src/main/scala/endless/protobuf/ProtobufCommandProtocol.scala
@@ -1,0 +1,24 @@
+package endless.protobuf
+
+import endless.core.protocol.{CommandProtocol, Decoder, Encoder, IncomingCommand, OutgoingCommand}
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+trait ProtobufCommandProtocol[Alg[_[_]]] extends CommandProtocol[Alg] {
+  protected def outgoingCommand[
+      C <: GeneratedMessage: GeneratedMessageCompanion,
+      R <: GeneratedMessage: GeneratedMessageCompanion,
+      A
+  ](command: C, replyMapper: R => A): OutgoingCommand[A] = new OutgoingCommand[A] {
+    override def payload: Array[Byte] = ProtobufEncoder[C].encode(command)
+    override def replyDecoder: Decoder[A] = ProtobufDecoder[R].map(replyMapper)
+  }
+
+  protected def incomingCommand[F[_], R <: GeneratedMessage: GeneratedMessageCompanion, A](
+      run: Alg[F] => F[A],
+      replyContramapper: A => R
+  ): IncomingCommand[F, Alg] = new IncomingCommand[F, Alg] {
+    override type Reply = A
+    override def runWith(alg: Alg[F]): F[A] = run(alg)
+    override def replyEncoder: Encoder[A] = ProtobufEncoder[R].contramap(replyContramapper)
+  }
+}

--- a/protobuf/src/main/scala/endless/protobuf/ProtobufDecoder.scala
+++ b/protobuf/src/main/scala/endless/protobuf/ProtobufDecoder.scala
@@ -1,0 +1,9 @@
+package endless.protobuf
+
+import endless.core.protocol.Decoder
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+object ProtobufDecoder {
+  def apply[A <: GeneratedMessage: GeneratedMessageCompanion]: Decoder[A] =
+    (payload: Array[Byte]) => implicitly[GeneratedMessageCompanion[A]].parseFrom(payload)
+}

--- a/protobuf/src/main/scala/endless/protobuf/ProtobufEncoder.scala
+++ b/protobuf/src/main/scala/endless/protobuf/ProtobufEncoder.scala
@@ -1,0 +1,9 @@
+package endless.protobuf
+
+import endless.core.protocol.Encoder
+import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
+
+object ProtobufEncoder {
+  implicit def apply[A <: GeneratedMessage: GeneratedMessageCompanion]: Encoder[A] =
+    (a: A) => implicitly[GeneratedMessageCompanion[A]].toByteArray(a)
+}

--- a/protobuf/src/test/protobuf/dummy.proto
+++ b/protobuf/src/test/protobuf/dummy.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package endless.protobuf.test.proto;
+
+message DummyCommand {
+  string x = 1;
+  int32 y = 2;
+}
+
+message DummyReply {
+  bool ok = 1;
+}

--- a/protobuf/src/test/scala/endless/protobuf/ProtobufCommandProtocolSuite.scala
+++ b/protobuf/src/test/scala/endless/protobuf/ProtobufCommandProtocolSuite.scala
@@ -1,0 +1,34 @@
+package endless.protobuf
+import cats.{Functor, Id}
+import endless.core.protocol.{Decoder, IncomingCommand, OutgoingCommand}
+import endless.protobuf.test.proto.dummy.{DummyCommand, DummyReply}
+import org.scalacheck.Prop.forAll
+import cats.syntax.functor._
+
+class ProtobufCommandProtocolSuite extends munit.ScalaCheckSuite {
+  test("protobuf command protocol") {
+    forAll { (int: Int, str: String, reply: Boolean) =>
+      val outgoingCommand = protocol.client.dummy(str, int)
+      val incomingCommand = protocol.server[Id].decode(outgoingCommand.payload)
+      val encodedReply = incomingCommand
+        .runWith((_: String, _: Int) => reply)
+        .map(incomingCommand.replyEncoder.encode)
+      assertEquals(outgoingCommand.replyDecoder.decode(encodedReply), reply)
+    }
+  }
+
+  val protocol = new ProtobufCommandProtocol[DummyAlg] {
+    override def server[F[_]]: Decoder[IncomingCommand[F, DummyAlg]] =
+      ProtobufDecoder[DummyCommand].map { case DummyCommand(x, y, _) =>
+        incomingCommand[F, DummyReply, Boolean](_.dummy(x, y), DummyReply(_))
+      }
+
+    override def client: DummyAlg[OutgoingCommand[*]] = (x: String, y: Int) =>
+      outgoingCommand[DummyCommand, DummyReply, Boolean](DummyCommand(x, y), _.ok)
+  }
+
+  trait DummyAlg[F[_]] {
+    def dummy(x: String, y: Int): F[Boolean]
+  }
+
+}

--- a/scodec/src/main/scala/endless/scodec/ScodecDecoder.scala
+++ b/scodec/src/main/scala/endless/scodec/ScodecDecoder.scala
@@ -16,5 +16,5 @@ class ScodecDecoder[+A](implicit decoder: scodec.Decoder[A]) extends Decoder[A] 
 object ScodecDecoder {
   final case class DecodingException(message: String) extends RuntimeException(message)
 
-  def apply[A: scodec.Decoder]: ScodecDecoder[A] = new ScodecDecoder[A]
+  implicit def apply[A: scodec.Decoder]: ScodecDecoder[A] = new ScodecDecoder[A]
 }

--- a/scodec/src/test/scala/endless/scodec/ScodecCommandProtocolSuite.scala
+++ b/scodec/src/test/scala/endless/scodec/ScodecCommandProtocolSuite.scala
@@ -20,9 +20,9 @@ class ScodecCommandProtocolSuite extends munit.ScalaCheckSuite {
 
   val protocol = new ScodecCommandProtocol[DummyAlg] {
     def server[F[_]]: Decoder[IncomingCommand[F, DummyAlg]] =
-      ScodecDecoder(DummyCommand.scodecDecoder.map { case DummyCommand(x, y) =>
+      ScodecDecoder(DummyCommand.scodecDecoder).map { case DummyCommand(x, y) =>
         incomingCommand[F, Boolean](_.dummy(x, y))
-      })
+      }
 
     def client: DummyAlg[OutgoingCommand[*]] = (x: Int, y: String) =>
       outgoingCommand[DummyCommand, Boolean](DummyCommand(x, y))


### PR DESCRIPTION
Add some helpers to make it easy to define command protocols using protobuf

scalapb doesn't define a codec-like API but we can still take advantage of the implicit `GeneratedMessageCompanion` to provide some generic handling