### PR TITLE
Support for cats-effect-kernel typeclasses in Effector algebras

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,8 +41,9 @@ inThisBuild(
 lazy val core = (project in file("core"))
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= cats ++ catsTagless ++ log4cats ++ (catsLaws ++ catsTestkit ++ mUnit)
-      .map(_ % Test)
+    libraryDependencies ++= cats ++ catsTagless ++ catsEffectKernel ++ log4cats ++
+      (catsLaws ++ catsEffectLaws ++ catsEffect ++ catsTestkit ++ catsEffectTestKit ++ mUnit ++ kittens)
+        .map(_ % Test)
   )
   .settings(name := "endless-core")
 

--- a/core/src/main/scala/endless/core/interpret/EffectorT.scala
+++ b/core/src/main/scala/endless/core/interpret/EffectorT.scala
@@ -1,11 +1,14 @@
 package endless.core.interpret
 
-import cats.data.ReaderWriterStateT
+import cats.data.{IndexedReaderWriterStateT, ReaderWriterStateT}
+import cats.effect.kernel._
+import cats.syntax.all._
 import cats.tagless.FunctorK
 import cats.tagless.syntax.functorK._
-import cats.{Applicative, Monad, ~>}
+import cats.{Applicative, Monad, Monoid, ~>}
 import endless.core.entity.Effector
 
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration.FiniteDuration
 
 object EffectorT extends LoggerLiftingHelper {
@@ -28,7 +31,17 @@ object EffectorT extends LoggerLiftingHelper {
 
   /** `EffectorT[F, S, A]` is a type alias for `ReaderWriterStateT` monad transformer from cats. It
     * uses `Reader` to allow access to ready-only entity state and algebra and `State` to update the
-    * passivation activation schedule (`Writer` is unused)
+    * passivation activation schedule (`Writer` is unused). Instances are provided for cats-effect
+    * kernel typeclasses, so that effector algebras can make use of e.g. `Async`.
+    *
+    * ``Implementation note: cats-effect itself purposefully omits instances of Concurrent and Async
+    * for RWST, because the general semantics of State are understood as function composition, which
+    * is inherently sequential and thus expects determinism. However, in the specific context of
+    * EffectorT, where the state in RWST only represents PassivationState, we consider the
+    * possibility of non-determinism acceptable. Indeed, its semantics are that the last emitted
+    * passivation setting is the one applied to the entity (we don't provide a get). Therefore, even
+    * if convoluted behavior would lead to two fibers racing to define the passivation state, the
+    * end-result would be the same as e.g. encoding it with WriterT (which supports Concurrent)``
     * @tparam F
     *   context
     * @tparam S
@@ -62,11 +75,9 @@ object EffectorT extends LoggerLiftingHelper {
     object Disabled extends PassivationState
   }
 
-  trait EffectorLift[G[_], F[_], S, Alg[_[_]]] extends Effector[G, S, Alg]
-
   implicit def instance[F[_]: Applicative, S, Alg[_[_]]: FunctorK]
-      : EffectorLift[EffectorT[F, S, Alg, *], F, S, Alg] =
-    new EffectorLift[EffectorT[F, S, Alg, *], F, S, Alg] {
+      : Effector[EffectorT[F, S, Alg, *], S, Alg] =
+    new Effector[EffectorT[F, S, Alg, *], S, Alg] {
       def read: EffectorT[F, S, Alg, Option[S]] = stateReader[F, S, Alg]
       def enablePassivation(after: FiniteDuration): EffectorT[F, S, Alg, Unit] = passivationEnabler(
         after
@@ -79,6 +90,207 @@ object EffectorT extends LoggerLiftingHelper {
   def liftF[F[_]: Applicative, S, Alg[_[_]], A](fa: F[A]): EffectorT[F, S, Alg, A] =
     ReaderWriterStateT.liftF(fa)
 
-  implicit def liftK[F[_]: Applicative, S, Alg[_[_]], A]: F ~> EffectorT[F, S, Alg, *] =
+  implicit def liftK[F[_]: Applicative, S, Alg[_[_]]]: F ~> EffectorT[F, S, Alg, *] =
     ReaderWriterStateT.liftK
+
+  implicit def asyncForEffectorT[F[_], S, Alg[_[_]]](implicit
+      F0: Async[F],
+      K0: FunctorK[Alg]
+  ): Async[EffectorT[F, S, Alg, *]] = new EffectorTAsync[F, S, Alg] {
+    implicit protected def F: Async[F] = F0
+    implicit protected def FunctorKAlg: FunctorK[Alg] = K0
+  }
+
+  private[interpret] trait EffectorTMonadCancel[F[_], S, Alg[_[_]], E]
+      extends MonadCancel[EffectorT[F, S, Alg, *], E] {
+    private val monadCancel =
+      MonadCancel.monadCancelForReaderWriterStateT[F, Env[S, Alg[F]], Unit, PassivationState, E]
+
+    implicit protected def F: MonadCancel[F, E]
+
+    def forceR[A, B](fa: EffectorT[F, S, Alg, A])(
+        fb: EffectorT[F, S, Alg, B]
+    ): EffectorT[F, S, Alg, B] = monadCancel.forceR(fa)(fb)
+
+    def uncancelable[A](
+        body: Poll[EffectorT[F, S, Alg, *]] => EffectorT[F, S, Alg, A]
+    ): EffectorT[F, S, Alg, A] = monadCancel.uncancelable(body)
+
+    def canceled: EffectorT[F, S, Alg, Unit] = monadCancel.canceled
+
+    def onCancel[A](
+        fa: EffectorT[F, S, Alg, A],
+        fin: EffectorT[F, S, Alg, Unit]
+    ): EffectorT[F, S, Alg, A] = monadCancel.onCancel(fa, fin)
+
+    def flatMap[A, B](fa: EffectorT[F, S, Alg, A])(
+        f: A => EffectorT[F, S, Alg, B]
+    ): EffectorT[F, S, Alg, B] = monadCancel.flatMap(fa)(f)
+
+    def tailRecM[A, B](a: A)(f: A => EffectorT[F, S, Alg, Either[A, B]]): EffectorT[F, S, Alg, B] =
+      monadCancel.tailRecM(a)(f)
+
+    def raiseError[A](e: E): EffectorT[F, S, Alg, A] = monadCancel.raiseError(e)
+
+    def handleErrorWith[A](fa: EffectorT[F, S, Alg, A])(
+        f: E => EffectorT[F, S, Alg, A]
+    ): EffectorT[F, S, Alg, A] = monadCancel.handleErrorWith(fa)(f)
+
+    def pure[A](x: A): EffectorT[F, S, Alg, A] = monadCancel.pure(x)
+  }
+
+  private[interpret] trait EffectorTGenSpawn[F[_], S, Alg[_[_]], E]
+      extends GenSpawn[EffectorT[F, S, Alg, *], E]
+      with EffectorTMonadCancel[F, S, Alg, E] {
+    implicit protected def F: GenSpawn[F, E]
+    def start[A](
+        fa: EffectorT[F, S, Alg, A]
+    ): EffectorT[F, S, Alg, Fiber[EffectorT[F, S, Alg, *], E, A]] =
+      ReaderWriterStateT { case (env, passivation) =>
+        F
+          .start(fa.run(env, passivation))
+          .map(fiber => ((), passivation, liftFiber[A](fiber)))
+      }
+
+    private def liftOutcome[A](
+        oc: Outcome[F, E, (Unit, PassivationState, A)]
+    ): Outcome[EffectorT[F, S, Alg, *], E, A] = {
+      oc match {
+        case Outcome.Succeeded(fa) =>
+          val fs = fa.map { case (_, passivation, _) => passivation }
+          val faa = fa.map { case (_, _, a) => a }
+          Outcome.Succeeded(
+            ReaderWriterStateT
+              .setF[F, Env[S, Alg[F]], Unit, PassivationState](fs)
+              .flatMap(_ => ReaderWriterStateT.liftF(faa))
+          )
+        case Outcome.Errored(e) => Outcome.Errored(e)
+        case Outcome.Canceled() => Outcome.Canceled()
+      }
+    }
+
+    private def liftFiber[A](
+        fib: Fiber[F, E, (Unit, PassivationState, A)]
+    ): Fiber[EffectorT[F, S, Alg, *], E, A] =
+      new Fiber[EffectorT[F, S, Alg, *], E, A] {
+        def cancel: EffectorT[F, S, Alg, Unit] = liftF(fib.cancel)
+        def join: EffectorT[F, S, Alg, Outcome[EffectorT[F, S, Alg, *], E, A]] =
+          liftF(fib.join.map(liftOutcome))
+      }
+
+    def never[A]: EffectorT[F, S, Alg, A] = liftF(F.never)
+
+    def cede: EffectorT[F, S, Alg, Unit] = liftF(F.cede)
+
+    def racePair[A, B](
+        fa: EffectorT[F, S, Alg, A],
+        fb: EffectorT[F, S, Alg, B]
+    ): EffectorT[F, S, Alg, Either[
+      (Outcome[EffectorT[F, S, Alg, *], E, A], Fiber[EffectorT[F, S, Alg, *], E, B]),
+      (Fiber[EffectorT[F, S, Alg, *], E, A], Outcome[EffectorT[F, S, Alg, *], E, B])
+    ]] = ReaderWriterStateT { case (env, passivation) =>
+      F.uncancelable(poll =>
+        poll(
+          F
+            .racePair(fa.run(env, passivation), fb.run(env, passivation))
+            .map {
+              case Left((oc, fib))  => Left((liftOutcome(oc), liftFiber(fib)))
+              case Right((fib, oc)) => Right((liftFiber(fib), liftOutcome(oc)))
+            }
+            .map(((), passivation, _))
+        )
+      )
+    }
+
+    def unique: EffectorT[F, S, Alg, Unique.Token] = liftF(F.unique)
+  }
+
+  private[interpret] trait EffectorTGenConcurrent[F[_], S, Alg[_[_]], E]
+      extends GenConcurrent[EffectorT[F, S, Alg, *], E]
+      with EffectorTGenSpawn[F, S, Alg, E] {
+    implicit protected def F: GenConcurrent[F, E]
+    def ref[A](a: A): EffectorT[F, S, Alg, Ref[EffectorT[F, S, Alg, *], A]] =
+      liftF(F.map(F.ref(a))(_.mapK(liftK)))
+    def deferred[A]: EffectorT[F, S, Alg, Deferred[EffectorT[F, S, Alg, *], A]] =
+      liftF(F.map(F.deferred[A])(_.mapK(liftK)))
+
+    override def racePair[A, B](
+        fa: EffectorT[F, S, Alg, A],
+        fb: EffectorT[F, S, Alg, B]
+    ): EffectorT[F, S, Alg, Either[
+      (Outcome[EffectorT[F, S, Alg, *], E, A], Fiber[EffectorT[F, S, Alg, *], E, B]),
+      (Fiber[EffectorT[F, S, Alg, *], E, A], Outcome[EffectorT[F, S, Alg, *], E, B])
+    ]] =
+      super.racePair(fa, fb)
+  }
+
+  private[interpret] trait EffectorTClock[F[_], S, Alg[_[_]]]
+      extends Clock[EffectorT[F, S, Alg, *]] {
+    private val clock = Clock.clockForReaderWriterStateT[F, Env[S, Alg[F]], Unit, PassivationState]
+    implicit protected def C: Clock[F]
+    implicit protected def F: Monad[F]
+    def applicative: Applicative[EffectorT[F, S, Alg, *]]
+    def monotonic: EffectorT[F, S, Alg, FiniteDuration] = clock.monotonic
+    def realTime: EffectorT[F, S, Alg, FiniteDuration] = clock.realTime
+  }
+
+  private[interpret] trait EffectorTGenTemporal[F[_], S, Alg[_[_]], E]
+      extends GenTemporal[EffectorT[F, S, Alg, *], E]
+      with EffectorTGenConcurrent[F, S, Alg, E]
+      with EffectorTClock[F, S, Alg] {
+    implicit protected def F: GenTemporal[F, E]
+    protected def C: Clock[F] = F
+
+    def sleep(time: FiniteDuration): EffectorT[F, S, Alg, Unit] = liftF(F.sleep(time))
+  }
+
+  private[interpret] trait EffectorTSync[F[_], S, Alg[_[_]]]
+      extends Sync[EffectorT[F, S, Alg, *]]
+      with EffectorTMonadCancel[F, S, Alg, Throwable]
+      with EffectorTClock[F, S, Alg] {
+    implicit protected def F: Sync[F]
+    private val sync = Sync.syncForReaderWriterStateT[F, Env[S, Alg[F]], Unit, PassivationState]
+    def suspend[A](hint: Sync.Type)(thunk: => A): EffectorT[F, S, Alg, A] =
+      sync.suspend(hint)(thunk)
+  }
+
+  private[interpret] trait EffectorTAsync[F[_], S, Alg[_[_]]]
+      extends Async[EffectorT[F, S, Alg, *]]
+      with EffectorTSync[F, S, Alg]
+      with EffectorTGenTemporal[F, S, Alg, Throwable] {
+    implicit protected def F: Async[F]
+    implicit protected def FunctorKAlg: FunctorK[Alg]
+
+    def evalOn[A](fa: EffectorT[F, S, Alg, A], ec: ExecutionContext): EffectorT[F, S, Alg, A] =
+      ReaderWriterStateT { case (env, passivation) => F.evalOn(fa.run(env, passivation), ec) }
+
+    def executionContext: EffectorT[F, S, Alg, ExecutionContext] =
+      liftF(F.executionContext)
+
+    override def never[A]: EffectorT[F, S, Alg, A] = super.never
+
+    override def unique: EffectorT[F, S, Alg, Unique.Token] = super.unique
+
+    def cont[K, R](body: Cont[EffectorT[F, S, Alg, *], K, R]): EffectorT[F, S, Alg, R] =
+      ReaderWriterStateT { case (env, passivation) =>
+        F.cont(new Cont[F, K, (Unit, PassivationState, R)] {
+          def apply[G[_]](implicit
+              G: MonadCancel[G, Throwable]
+          ): (Either[Throwable, K] => Unit, G[K], F ~> G) => G[(Unit, PassivationState, R)] =
+            (cb, ga, nat) => {
+              val natT: EffectorT[F, S, Alg, *] ~> EffectorT[G, S, Alg, *] =
+                new ~>[EffectorT[F, S, Alg, *], EffectorT[G, S, Alg, *]] {
+                  def apply[A](fa: EffectorT[F, S, Alg, A]): EffectorT[G, S, Alg, A] =
+                    ReaderWriterStateT { case (_, _) =>
+                      nat(fa.run(env, passivation))
+                    }
+                }
+              body[EffectorT[G, S, Alg, *]]
+                .apply(cb, liftF(ga), natT)
+                .run(Env(env.state, FunctorK[Alg].mapK(env.entity)(nat)), passivation)
+            }
+        })
+      }
+
+  }
 }

--- a/core/src/main/scala/endless/core/interpret/EntityLift.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityLift.scala
@@ -1,8 +1,0 @@
-package endless.core.interpret
-
-import endless.core.entity.Entity
-
-/** Any effect of type G[A] can be lifted into F[A] thus enabling entity capability - we typically
-  * lift `EntityT` for interpretation
-  */
-trait EntityLift[G[_], F[_], S, E] extends Entity[G, S, E]

--- a/core/src/main/scala/endless/core/interpret/EntityT.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityT.scala
@@ -8,6 +8,7 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import cats.{Applicative, Functor, Monad, ~>}
 import endless.core.data.{EventsFolder, Folded}
+import endless.core.entity.Entity
 import endless.core.event.EventApplier
 
 /** `EntityT[F, S, E, A]`` is data type implementing the `Entity[F, S, E]` state reader and event
@@ -71,9 +72,14 @@ object EntityT extends EntityRunFunctions with LoggerLiftingHelper {
 
   def reader[F[_]: Monad, S, E]: EntityT[F, S, E, Option[S]] = new EntityT(read[F, S, E])
 
+  /** Given that a monad instance can be found for F, this provides an EntityT
+    * transformer instance for it. This is used by `deployEntity`: the `createEntity` creator for entity
+    * algebra can thus be injected with an instance of `Entity[F[_]]` interpreted with EntityT[F, S,
+    * E, *]
+    */
   implicit def instance[F[_], S, E](implicit
       monad0: Monad[F]
-  ): EntityLift[EntityT[F, S, E, *], F, S, E] =
+  ): Entity[EntityT[F, S, E, *], S, E] =
     new EntityTLiftInstance[F, S, E] {
       override protected implicit def monad: Monad[F] = monad0
     }

--- a/core/src/main/scala/endless/core/interpret/EntityTLiftInstance.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityTLiftInstance.scala
@@ -7,8 +7,9 @@ import cats.syntax.applicative._
 import cats.syntax.either._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
+import endless.core.entity.Entity
 
-trait EntityTLiftInstance[F[_], S, E] extends EntityLift[EntityT[F, S, E, *], F, S, E] {
+trait EntityTLiftInstance[F[_], S, E] extends Entity[EntityT[F, S, E, *], S, E] {
   protected implicit def monad: Monad[F]
   override def read: EntityT[F, S, E, Option[S]] = EntityT.reader[F, S, E]
 

--- a/core/src/test/scala/endless/core/interpret/EffectorTSuite.scala
+++ b/core/src/test/scala/endless/core/interpret/EffectorTSuite.scala
@@ -1,51 +1,120 @@
 package endless.core.interpret
 
-import cats.laws.discipline.MonadTests
-import cats.syntax.applicative._
-import cats.syntax.flatMap._
+import cats.data.Chain
+import cats.effect.{Clock, Concurrent, GenSpawn, GenTemporal, IO, MonadCancel, Sync, Temporal}
+import cats.effect.laws.AsyncTests
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.{MiniInt, MonadTests}
+import cats.laws.discipline.eq._
+import cats.syntax.all._
+import cats.derived.auto.eq._
+import cats.derived.auto.order._
+import cats.effect.kernel.{Async, GenConcurrent}
+import cats.effect.testkit.TestInstances
+import cats.tagless.FunctorK
 import cats.tests.ListWrapper
-import cats.tests.ListWrapper._
-import cats.{Applicative, Eq, Functor, Monad}
-import endless.core.interpret.EffectorT.{EffectorT, PassivationState, _}
+import cats.{Applicative, Eq, Functor, Monad, Order, ~>}
+import endless.core.interpret.EffectorT._
 import munit.DisciplineSuite
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary._
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.typelevel.log4cats.Logger
 
-import scala.concurrent.duration.Duration
+import scala.language.implicitConversions
+import scala.concurrent.duration._
 
-class EffectorTSuite extends DisciplineSuite {
-  type State = String
+class EffectorTSuite extends DisciplineSuite with TestInstances {
+  type State = MiniInt
   type Value = Int
   trait Alg[F[_]] {
     def universe: F[Int]
   }
-  val algImpl = new Alg[ListWrapper] {
-    def universe: ListWrapper[Int] = 42.pure[ListWrapper]
+  implicit val functorKAlg: FunctorK[Alg] = new FunctorK[Alg] {
+    def mapK[F[_], G[_]](af: Alg[F])(fk: F ~> G): Alg[G] = new Alg[G] {
+      def universe: G[Value] = fk(af.universe)
+    }
   }
-  implicit val F: Monad[ListWrapper] = ListWrapper.monad
+  def algImpl[F[_]: Applicative]: Alg[F] = new Alg[F] {
+    def universe: F[Int] = 42.pure[F]
+  }
+  implicit val listWrapperMonad: Monad[ListWrapper] = ListWrapper.monad
 
-  implicit def eqEffectorT[A: Eq]: Eq[EffectorT[ListWrapper, State, Alg, A]] =
-    (x: EffectorT[ListWrapper, State, Alg, A], y: EffectorT[ListWrapper, State, Alg, A]) =>
-      x.run(None, algImpl, PassivationState.Disabled) == y.run(
+  implicit val ticker: Ticker = Ticker()
+
+  implicit def eqEffectorT[F[_]: Monad, A: Eq](implicit
+      eqF: Eq[F[(Unit, PassivationState, A)]]
+  ): Eq[EffectorT[F, State, Alg, A]] =
+    (x: EffectorT[F, State, Alg, A], y: EffectorT[F, State, Alg, A]) =>
+      x.run(None, algImpl[F], PassivationState.Disabled) === y.run(
         None,
-        algImpl,
+        algImpl[F],
         PassivationState.Disabled
       )
 
-  implicit def arbitrary[F[_]: Monad, A](implicit
-      F: Arbitrary[F[A]]
-  ): Arbitrary[EffectorT[F, State, Alg, A]] =
-    Arbitrary(F.arbitrary.map(EffectorT.liftF(_)))
+  implicit def ordEffectorTIO(implicit
+      ticker: Ticker
+  ): Order[EffectorT[IO, State, Alg, FiniteDuration]] = {
+    implicit val passivationStateOrder: Order[PassivationState] =
+      (x: PassivationState, y: PassivationState) =>
+        (x, y) match {
+          case (PassivationState.Disabled, PassivationState.Disabled) => 0
+          case (PassivationState.After(before), PassivationState.After(after)) =>
+            Order[FiniteDuration].compare(before, after)
+          case (PassivationState.After(_), PassivationState.Disabled) => 1
+          case (PassivationState.Disabled, PassivationState.After(_)) => -1
+        }
+
+    Order.by { ioaO =>
+      unsafeRun(ioaO.run(None, algImpl[IO], PassivationState.Disabled))
+        .fold(None, _ => None, fa => fa)
+    }
+  }
+
+  implicit def cogenForEffectorT[F[_]: Monad, A](implicit
+      cogenFA: Cogen[F[A]]
+  ): Cogen[EffectorT[F, State, Alg, A]] =
+    cogenFA.contramap(_.runA(Env(None, algImpl[F]), PassivationState.Disabled))
+
+  implicit def arbitraryRun[F[_]: Monad, A](implicit
+      A: Arbitrary[A]
+  ): Arbitrary[(Env[State, Alg[F]], PassivationState) => F[(Unit, PassivationState, A)]] =
+    Arbitrary(
+      A.arbitrary.map(a =>
+        (env: Env[State, Alg[F]], passivation: PassivationState) =>
+          EffectorT.liftF(Applicative[F].pure(a)).run(env, passivation)
+      )
+    )
+
+  implicit def execEffectorT[S](
+      sbool: EffectorT[IO, S, Alg, Boolean]
+  )(implicit ticker: Ticker): Prop =
+    Prop(
+      unsafeRun(sbool.run(None, algImpl[IO], PassivationState.Disabled)).fold(
+        false,
+        _ => false,
+        pO => pO.fold(false) { case (_, _, bool) => bool }
+      )
+    )
 
   // check if resolves
   Functor[EffectorT[ListWrapper, State, Alg, *]]
   Applicative[EffectorT[ListWrapper, State, Alg, *]]
   Monad[EffectorT[ListWrapper, State, Alg, *]]
+  MonadCancel[EffectorT[IO, State, Alg, *]]
+  GenSpawn[EffectorT[IO, State, Alg, *]]
+  GenConcurrent[EffectorT[IO, State, Alg, *]]
+  Clock[EffectorT[IO, State, Alg, *]]
+  GenTemporal[EffectorT[IO, State, Alg, *]]
+  Sync[EffectorT[IO, State, Alg, *]]
+  Async[EffectorT[IO, State, Alg, *]]
 
   checkAll(
     "EffectorT.MonadLaws",
     MonadTests[EffectorT[ListWrapper, State, Alg, *]].monad[Value, Value, Value]
+  )
+
+  checkAll(
+    "EffectorT.AsyncLaws",
+    AsyncTests[EffectorT[IO, State, Alg, *]].async[Value, Value, Value](10.millis)
   )
 
   test("passivationEnabler enables passivation") {

--- a/documentation/src/main/paradox/effector.md
+++ b/documentation/src/main/paradox/effector.md
@@ -26,6 +26,10 @@ In the provided Akka runtime, read-only commands (commands that do not generate 
 Defining an effector is entirely optional with the Akka runtime, pass-in `(_, _) => EffectorT.unit` in @scaladoc[deployEntity](endless.runtime.akka.Deployer) to disable effector.
 @@@
 
+@@@ note
+`EffectorT` (the monad transformer used to interpret the effector algebra) supports cats-effect kernel typeclasses all to way down to `Async`, which makes it possible to take advantage of semantics such as timeouts, concurrency, etc.
+@@@
+
 ## State-derived side-effects
 @scaladoc[StateReader](endless.core.entity.StateReader) allows reading the updated entity state after event persistence or recovery. 
 

--- a/example/src/main/scala/endless/example/ExampleApp.scala
+++ b/example/src/main/scala/endless/example/ExampleApp.scala
@@ -147,10 +147,12 @@ object ExampleApp {
       }
     } yield result
 
-  implicit def alwaysAvailable[F[_]: Logger: Monad]: AvailabilityAlg[F] =
+  implicit def alwaysAvailable[F[_]: Logger: Monad: Async]: AvailabilityAlg[F] =
     (time: Instant, passengerCount: Int) =>
       Logger[F].info(
         show"Checking if capacity is available for ${time.toString} and $passengerCount passengers"
+      ) >> Async[F].sleep(500.millis) >> Logger[F].info(
+        show"Availability confirmed for ${time.toString} and $passengerCount passengers"
       ) >> true
         .pure[F]
 }

--- a/example/src/test/scala/endless/example/ExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/ExampleAppSuite.scala
@@ -19,6 +19,7 @@ import org.http4s.implicits._
 
 import java.time.Instant
 import java.util.UUID
+import scala.concurrent.duration._
 
 class ExampleAppSuite extends munit.CatsEffectSuite {
   implicit val actorSystem: ActorSystem[Nothing] =
@@ -45,6 +46,7 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
     val bookingRequest = BookingRequest(Instant.now, 1, LatLon(0, 0), LatLon(1, 1))
     for {
       bookingID <- client().expect[BookingID](POST(bookingRequest, baseUri))
+      _ <- IO.sleep(1.second)
       _ <- assertIO(
         client().expect[Booking](GET(baseUri / bookingID.show)),
         Booking(
@@ -72,6 +74,7 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
       _ <- client().status(
         PATCH(BookingPatch(Some(LatLon(4, 4)), Some(LatLon(5, 5))), baseUri / bookingID.show)
       )
+      _ <- IO.sleep(1.second)
       _ <- assertIO(
         client().expect[Booking](GET(baseUri / bookingID.show)),
         Booking(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -34,6 +34,9 @@ object Dependencies {
   lazy val catsTagless = Seq("org.typelevel" %% "cats-tagless-macros" % catsTaglessVersion)
 
   lazy val catsEffectVersion = "3.3.14"
+  lazy val catsEffectKernel = Seq("org.typelevel" %% "cats-effect-kernel" % catsEffectVersion)
+  lazy val catsEffectLaws = Seq("org.typelevel" %% "cats-effect-laws" % catsEffectVersion)
+  lazy val catsEffectTestKit = Seq("org.typelevel" %% "cats-effect-testkit" % catsEffectVersion)
   lazy val catsEffectStd = Seq("org.typelevel" %% "cats-effect-std" % catsEffectVersion)
   lazy val catsEffect = Seq("org.typelevel" %% "cats-effect" % catsEffectVersion)
 
@@ -80,6 +83,9 @@ object Dependencies {
   lazy val scalacheckEffect = Seq(
     "org.typelevel" %% "scalacheck-effect-munit" % scalacheckEffectVersion
   )
+
+  lazy val kittensVersion = "2.3.0"
+  lazy val kittens = Seq("org.typelevel" %% "kittens" % kittensVersion)
 
   lazy val scodecCore = Seq("org.scodec" %% "scodec-core" % "1.11.9")
 }

--- a/runtime/src/main/scala/endless/runtime/akka/Deployer.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/Deployer.scala
@@ -238,7 +238,7 @@ trait Deployer {
         .runCommand(state, incomingCommand)
         .flatMap {
           case Left(error) =>
-            Logger[F].warn(error) >> Effect.unhandled[E, Option[S]].thenNoReply().pure
+            Logger[F].warn(error) >> Effect.unhandled[E, Option[S]].thenNoReply().pure[F]
           case Right((events, reply)) if events.nonEmpty =>
             Effect
               .persist(events.toList)
@@ -257,13 +257,13 @@ trait Deployer {
               .thenReply(command.replyTo) { _: Option[S] =>
                 Reply(incomingCommand.replyEncoder.encode(reply))
               }
-              .pure
+              .pure[F]
           case Right((_, reply)) =>
             Effect
               .reply[Reply, E, Option[S]](command.replyTo)(
                 Reply(incomingCommand.replyEncoder.encode(reply))
               )
-              .pure
+              .pure[F]
         }
       dispatcher.unsafeRunSync(effect)
     }


### PR DESCRIPTION
This PR makes it possible to use semantics from typeclasses such as `Async` from cats-effect, to represent timeouts, concurrency, etc.