### PR TITLE
Add durable entity support 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -92,13 +92,22 @@ lazy val protobufHelpers = (project in file("protobuf"))
   )
 
 lazy val example = (project in file("example"))
-  .dependsOn(core, runtime, circeHelpers)
+  .dependsOn(core, runtime, circeHelpers, protobufHelpers)
   .settings(commonSettings: _*)
   .settings(
-    libraryDependencies ++= catsEffect ++ http4s ++ blaze ++ akka ++ akkaTest ++ logback ++ log4catsSlf4j ++ (mUnit ++ catsEffectMUnit ++ scalacheckEffect ++ log4catsTesting)
+    libraryDependencies ++= catsEffect ++ http4s ++ blaze ++ akka ++ scalapbCustomizations ++ akkaTest ++ logback ++ log4catsSlf4j ++ (mUnit ++ catsEffectMUnit ++ scalacheckEffect ++ log4catsTesting)
       .map(_ % Test)
   )
   .settings(name := "endless-example", run / fork := true, publish / skip := true)
+  .settings(
+    Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),
+    Compile / PB.targets := Seq(
+      scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
+    ),
+    Test / PB.targets := Seq(
+      scalapb.gen() -> (Test / sourceManaged).value / "scalapb"
+    )
+  )
 
 // Generate API documentation per module, as documented in https://www.scala-sbt.org/sbt-site/api-documentation.html#scaladoc-from-multiple-projects
 

--- a/build.sbt
+++ b/build.sbt
@@ -75,7 +75,11 @@ lazy val scodecHelpers = (project in file("scodec"))
 lazy val protobufHelpers = (project in file("protobuf"))
   .dependsOn(core)
   .settings(commonSettings: _*)
-  .settings(libraryDependencies ++= mUnit.map(_ % Test))
+  .settings(
+    libraryDependencies ++= (akkaActorTyped % akkaVersion) +: mUnit.map(
+      _ % Test
+    ) :+ akkaTypedTestkit % akkaVersion % Test
+  )
   .settings(name := "endless-protobuf-helpers")
   .settings(
     Project.inConfig(Test)(sbtprotoc.ProtocPlugin.protobufConfigSettings),

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "reach, diff, files"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true

--- a/core/src/main/scala/endless/core/entity/DurableEntity.scala
+++ b/core/src/main/scala/endless/core/entity/DurableEntity.scala
@@ -1,0 +1,24 @@
+package endless.core.entity
+
+/** `DurableEntity[F, S]` is the ability to read and write an entity state of type `S` together with
+  * the ability to compose such dependent effectful functions.
+  *
+  * These dual reader/writer abilities are what is needed to describe command handler behavior. This
+  * model enables a stateful entity to store the full state after processing each command instead of
+  * using event sourcing. When interpreting code involving `DurableEntity`, the final resulting
+  * value in the monadic chain is typically understood as the reply, and any written state is
+  * persisted behind the scenes by the runtime. Read always provides the state as it was last
+  * written.
+  *
+  * @tparam F
+  *   context
+  * @tparam S
+  *   state
+  *
+  * @see
+  *   `Entity` for the event-sourcing equivalent
+  */
+trait DurableEntity[F[_], S]
+    extends StateReader[F, S]
+    with StateReaderHelpers[F, S]
+    with StateWriter[F, S]

--- a/core/src/main/scala/endless/core/entity/Entity.scala
+++ b/core/src/main/scala/endless/core/entity/Entity.scala
@@ -1,14 +1,9 @@
 package endless.core.entity
 
-import cats.Monad
-import cats.data.EitherT
-import cats.syntax.either._
-import endless.\/
 import endless.core.event.EventWriter
 
 /** `Entity[F, S, E]` is the ability to read an event-sourced entity state of type `S` and append
-  * events of type `E` affecting this state, together with the ability to compose such dependent
-  * effectful functions.
+  * events of type `E` affecting this state.
   *
   * These dual reader/writer abilities are what is needed to describe command handler behavior. When
   * interpreting code involving `Entity`, the final resulting value in the monadic chain is
@@ -22,95 +17,11 @@ import endless.core.event.EventWriter
   *   state
   * @tparam E
   *   event
+  *
+  * @see
+  *   `DurableEntity` for the equivalent without event-sourcing
   */
-trait Entity[F[_], S, E] extends StateReader[F, S] with EventWriter[F, E] with Monad[F] {
-
-  /** Convenience function which applies `fa` on the state if entity exists and wraps this in a
-    * `Right`, otherwise returns a `Left` with the provided error value.
-    * @param fa
-    *   function to apply on state
-    * @param ifUnknown
-    *   left value in case of missing entity
-    */
-  def ifKnown[Error, A](fa: S => A)(ifUnknown: => Error): F[Error \/ A] =
-    ifKnownF[Error, A](s => pure(fa(s)))(ifUnknown)
-
-  /** Convenience function which applies `fa` on the state if entity exists and wraps this in a
-    * `Right`, otherwise returns a `Left` with the provided error value.
-    * @param fa
-    *   function to apply on state
-    * @param ifUnknown
-    *   left value in case of missing entity
-    */
-  def ifKnownF[Error, A](fa: S => F[A])(ifUnknown: => Error): F[Error \/ A] =
-    ifKnownFE[Error, A](s => map(fa(s))(_.asRight))(ifUnknown)
-
-  /** Convenience function which applies `fa` on the state if entity exists, otherwise returns a
-    * `Left` with the provided error value.
-    * @param fa
-    *   function to apply on state
-    * @param ifUnknown
-    *   left value in case of missing entity
-    */
-  def ifKnownFE[Error, A](fa: S => F[Error \/ A])(ifUnknown: => Error): F[Error \/ A] =
-    flatMap(read) {
-      case Some(state) => fa(state)
-      case None        => pure(ifUnknown.asLeft)
-    }
-
-  /** Convenience function which applies `fa` on the state if entity exists and unwraps EitherT
-    * value, otherwise returns a `Left` with the provided error value.
-    * @param fa
-    *   function to apply on state
-    * @param ifUnknown
-    *   left value in case of missing entity
-    */
-  def ifKnownT[Error, A](fa: S => EitherT[F, Error, A])(ifUnknown: => Error): F[Error \/ A] =
-    ifKnownFE(s => fa(s).value)(ifUnknown)
-
-  /** Convenience function which returns a in a `Right` if entity doesn't yet exist, otherwise calls
-    * `ifKnown` with the state and wraps this in a `Left`.
-    * @param fa
-    *   success value when entity doesn't exist yet
-    * @param ifKnown
-    *   function to compute left value in case of existing entity
-    */
-  def ifUnknown[Error, A](a: => A)(ifKnown: S => Error): F[Error \/ A] =
-    ifUnknownF[Error, A](pure(a))(ifKnown)
-
-  /** Convenience function which invokes `fa` if entity doesn't yet exist and wraps this in a
-    * `Right`, otherwise calls `ifKnown` with the state and wraps this in a `Left`.
-    * @param fa
-    *   success value when entity doesn't exist yet
-    * @param ifKnown
-    *   function to compute left value in case of existing entity
-    */
-  def ifUnknownF[Error, A](fa: => F[A])(ifKnown: S => Error): F[Error \/ A] =
-    ifUnknownFE[Error, A](map(fa)(_.asRight))(ifKnown)
-
-  /** Convenience function which invokes `fa` if entity doesn't yet exist and wraps this in a
-    * `Right`, otherwise calls `ifKnown` with the state and wraps this in a `Left`.
-    * @param fa
-    *   success value when entity doesn't exist yet
-    * @param ifKnown
-    *   function to compute left value in case of existing entity
-    */
-  def ifUnknownFE[Error, A](fa: => F[Error \/ A])(ifKnown: S => Error): F[Error \/ A] =
-    flatMap(read) {
-      case None =>
-        fa
-      case Some(state) =>
-        pure(ifKnown(state).asLeft)
-    }
-
-  /** Convenience function which applies `fa` on the state if entity exists and unwraps EitherT
-    * value, otherwise returns a `Left` with the provided error value.
-    * @param fa
-    *   function to apply on state
-    * @param ifUnknown
-    *   left value in case of missing entity
-    */
-  def ifUnknownT[Error, A](fa: => EitherT[F, Error, A])(ifUnknown: S => Error): F[Error \/ A] =
-    ifUnknownFE(fa.value)(ifUnknown)
-
-}
+trait Entity[F[_], S, E]
+    extends StateReader[F, S]
+    with StateReaderHelpers[F, S]
+    with EventWriter[F, E]

--- a/core/src/main/scala/endless/core/entity/StateReader.scala
+++ b/core/src/main/scala/endless/core/entity/StateReader.scala
@@ -13,7 +13,7 @@ package endless.core.entity
   */
 trait StateReader[F[_], S] {
 
-  /** Read the state from the environment, returns None if the entity doesn't yet exist
+  /** Read the entity state, returns None if the entity doesn't yet exist
     * @return
     *   optional state in `F` context
     */

--- a/core/src/main/scala/endless/core/entity/StateReaderHelpers.scala
+++ b/core/src/main/scala/endless/core/entity/StateReaderHelpers.scala
@@ -1,0 +1,128 @@
+package endless.core.entity
+
+import cats.Monad
+import cats.data.EitherT
+import cats.syntax.applicative._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import endless.\/
+
+/** Set of convenience functions augmenting `StateReader` (that assume a `Monad` instance exists for
+  * `F`)
+  * @tparam F
+  *   context
+  * @tparam S
+  *   state
+  */
+trait StateReaderHelpers[F[_], S] extends StateReader[F, S] {
+  implicit def monad: Monad[F]
+
+  /** Convenience function which applies `fa` on the state if entity exists and wraps this in a
+    * `Right`, otherwise returns a `Left` with the provided error value.
+    * @param fa
+    *   function to apply on state
+    * @param ifUnknown
+    *   left value in case of missing entity
+    */
+  def ifKnown[Error, A](fa: S => A)(ifUnknown: => Error): F[Error \/ A] =
+    ifKnownF[Error, A](s => fa(s).pure)(ifUnknown)
+
+  /** Convenience function which applies `fa` on the state if entity exists and wraps this in a
+    * `Right`, otherwise returns a `Left` with the provided error value.
+    * @param fa
+    *   function to apply on state
+    * @param ifUnknown
+    *   left value in case of missing entity
+    */
+  def ifKnownF[Error, A](fa: S => F[A])(ifUnknown: => Error): F[Error \/ A] =
+    ifKnownFE[Error, A](s => fa(s).map(_.asRight))(ifUnknown)
+
+  /** Convenience function which applies `fa` on the state if entity exists, otherwise returns a
+    * `Left` with the provided error value.
+    * @param fa
+    *   function to apply on state
+    * @param ifUnknown
+    *   left value in case of missing entity
+    */
+  def ifKnownFE[Error, A](fa: S => F[Error \/ A])(ifUnknown: => Error): F[Error \/ A] =
+    ifKnownElse(fa)(ifUnknown.asLeft[A].pure)
+
+  /** Convenience function which applies `fa` on the state if entity exists and unwraps EitherT
+    * value, otherwise returns a `Left` with the provided error value.
+    * @param fa
+    *   function to apply on state
+    * @param ifUnknown
+    *   left value in case of missing entity
+    */
+  def ifKnownT[Error, A](fa: S => EitherT[F, Error, A])(ifUnknown: => Error): F[Error \/ A] =
+    ifKnownFE(s => fa(s).value)(ifUnknown)
+
+  /** Convenience function which applies `fa` on the state if entity exists, otherwise returns a
+    * default value
+    *
+    * @param fa
+    *   function to apply on state
+    * @param ifUnknownF
+    *   value in case of missing entity in `F` context
+    */
+  def ifKnownElse[A](fa: S => F[A])(ifUnknownF: => F[A]): F[A] =
+    read.flatMap {
+      case Some(state) => fa(state)
+      case None        => ifUnknownF
+    }
+
+  /** Convenience function which returns a in a `Right` if entity doesn't yet exist, otherwise calls
+    * `ifKnown` with the state and wraps this in a `Left`.
+    * @param fa
+    *   success value when entity doesn't exist yet
+    * @param ifKnown
+    *   function to compute left value in case of existing entity
+    */
+  def ifUnknown[Error, A](a: => A)(ifKnown: S => Error): F[Error \/ A] =
+    ifUnknownF[Error, A](a.pure)(ifKnown)
+
+  /** Convenience function which invokes `fa` if entity doesn't yet exist and wraps this in a
+    * `Right`, otherwise calls `ifKnown` with the state and wraps this in a `Left`.
+    * @param fa
+    *   success value when entity doesn't exist yet
+    * @param ifKnown
+    *   function to compute left value in case of existing entity
+    */
+  def ifUnknownF[Error, A](fa: => F[A])(ifKnown: S => Error): F[Error \/ A] =
+    ifUnknownFE[Error, A](fa.map(_.asRight))(ifKnown)
+
+  /** Convenience function which invokes `fa` if entity doesn't yet exist and wraps this in a
+    * `Right`, otherwise calls `ifKnown` with the state and wraps this in a `Left`.
+    * @param fa
+    *   success value when entity doesn't exist yet
+    * @param ifKnown
+    *   function to compute left value in case of existing entity
+    */
+  def ifUnknownFE[Error, A](fa: => F[Error \/ A])(ifKnown: S => Error): F[Error \/ A] =
+    ifUnknownElse(fa)(state => ifKnown(state).asLeft[A].pure)
+
+  /** Convenience function which invokes `fa` if entity doesn't yet exist, otherwise calls ,
+    * `ifKnown` with the the state and wraps this in a `Left`.
+    * @param fa
+    *   value wrapped in `EitherT` when entity doesn't exist yet
+    * @param ifKnown
+    *   function to compute left value in case of existing entity
+    */
+  def ifUnknownT[Error, A](fa: => EitherT[F, Error, A])(ifKnown: S => Error): F[Error \/ A] =
+    ifUnknownFE(fa.value)(ifKnown)
+
+  /** Convenience function which returns a value `fa` in `F` context, otherwise calls `ifKnown` with
+    * the state
+    *
+    * @param fa
+    *   value in case of missing entity in `F` context
+    * @param ifKnown
+    *   function to apply on state
+    */
+  def ifUnknownElse[A](fa: => F[A])(ifKnown: S => F[A]): F[A] =
+    read.flatMap {
+      case Some(state) => ifKnown(state)
+      case None        => fa
+    }
+}

--- a/core/src/main/scala/endless/core/entity/StateWriter.scala
+++ b/core/src/main/scala/endless/core/entity/StateWriter.scala
@@ -1,0 +1,36 @@
+package endless.core.entity
+
+/** `StateWriter[F, S]` is the ability to write a value of type `S`, where that value is
+  * semantically understood as the new state of the entity.
+  *
+  * @tparam F
+  *   context
+  * @tparam S
+  *   state
+  */
+trait StateWriter[F[_], S] {
+
+  /** Write the entity state
+    * @param s
+    *   entity state
+    * @return
+    *   unit in `F` context
+    */
+  def write(s: S): F[Unit]
+
+  /** Modify the entity state with the given function
+    * @param f
+    *   state modifier
+    * @return
+    *   unit in `F` context
+    */
+  def modify(f: S => S): F[Unit]
+
+  /** Modify the entity state with the given function expressed in `F` context
+    * @param f
+    *   state modifier in `F` context
+    * @return
+    *   unit in `F` context
+    */
+  def modifyF(f: S => F[S]): F[Unit]
+}

--- a/core/src/main/scala/endless/core/interpret/DurableEntityT.scala
+++ b/core/src/main/scala/endless/core/interpret/DurableEntityT.scala
@@ -1,0 +1,73 @@
+package endless.core.interpret
+
+import cats.data.{IndexedStateT, StateT}
+import cats.{Applicative, Functor, Monad, ~>}
+import endless.core.entity.DurableEntity
+
+object DurableEntityT extends LoggerLiftingHelper {
+  sealed trait State[+S]
+  object State {
+    case object None extends State[Nothing]
+    final case class Existing[S](state: S) extends State[S]
+    final case class Updated[S](state: S) extends State[S]
+  }
+
+  /** `DurableEntityT[F, S, A]` is a type alias for StateT monad transformer from cats. `State` is
+    * the state of the entity, which can be get (exposed as `read`) and set (exposed as `write`)
+    * @tparam F
+    *   context
+    * @tparam S
+    *   entity state
+    * @tparam A
+    *   value
+    */
+  type DurableEntityT[F[_], S, A] = StateT[F, State[S], A]
+
+  def liftF[F[_]: Applicative, S, A](fa: F[A]): DurableEntityT[F, S, A] = StateT.liftF(fa)
+
+  implicit def liftK[F[_]: Applicative, S]: F ~> DurableEntityT[F, S, *] = StateT.liftK
+
+  def unit[F[_]: Applicative, S]: DurableEntityT[F, S, Unit] = liftF(Applicative[F].unit)
+
+  def stateReader[F[_]: Applicative, S]: DurableEntityT[F, S, Option[S]] =
+    StateT.get[F, State[S]].map {
+      case State.None            => None
+      case State.Existing(state) => Some(state)
+      case State.Updated(state)  => Some(state)
+    }
+
+  def stateWriter[F[_]: Applicative, S](state: S): DurableEntityT[F, S, Unit] =
+    StateT.set(State.Updated(state))
+
+  def stateModifier[F[_]: Applicative, S](f: S => S): DurableEntityT[F, S, Unit] =
+    StateT.modify {
+      case State.None            => State.None
+      case State.Existing(state) => State.Updated(f(state))
+      case State.Updated(state)  => State.Updated(f(state))
+    }
+
+  def stateModifierF[F[_]: Applicative, S](f: S => F[S]): DurableEntityT[F, S, Unit] =
+    StateT.modifyF {
+      case State.None            => Applicative[F].pure(State.None)
+      case State.Existing(state) => Functor[F].map(f(state))(State.Updated(_))
+      case State.Updated(state)  => Functor[F].map(f(state))(State.Updated(_))
+    }
+
+  /** Given that a monad instance can be found for F, this provides an DurableEntityT transformer
+    * instance for it. This is used by `deployDurableEntity`: the `createEntity` creator for entity
+    * algebra can thus be injected with an instance of `DurableEntity[F[_]]` interpreted with
+    * DurableEntityT[F, S, *]
+    */
+  implicit def instance[F[_]: Monad, S]: DurableEntity[DurableEntityT[F, S, *], S] =
+    new DurableEntity[DurableEntityT[F, S, *], S] {
+      def read: DurableEntityT[F, S, Option[S]] = stateReader
+      def write(s: S): DurableEntityT[F, S, Unit] = stateWriter(s)
+      def modify(f: S => S): DurableEntityT[F, S, Unit] = stateModifier(f)
+      def modifyF(f: S => DurableEntityT[F, S, S]): DurableEntityT[F, S, Unit] =
+        stateModifierF(state => f(state).runA(State.Updated(state)))
+
+      implicit lazy val monad: Monad[DurableEntityT[F, S, *]] =
+        IndexedStateT.catsDataMonadForIndexedStateT
+    }
+
+}

--- a/core/src/main/scala/endless/core/interpret/EntityT.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityT.scala
@@ -72,15 +72,11 @@ object EntityT extends EntityRunFunctions with LoggerLiftingHelper {
 
   def reader[F[_]: Monad, S, E]: EntityT[F, S, E, Option[S]] = new EntityT(read[F, S, E])
 
-  /** Given that a monad instance can be found for F, this provides an EntityT
-    * transformer instance for it. This is used by `deployEntity`: the `createEntity` creator for entity
-    * algebra can thus be injected with an instance of `Entity[F[_]]` interpreted with EntityT[F, S,
-    * E, *]
+  /** Given that a monad instance can be found for F, this provides an EntityT transformer instance
+    * for it. This is used by `deployEntity`: the `createEntity` creator for entity algebra can thus
+    * be injected with an instance of `Entity[F[_]]` interpreted with EntityT[F, S, E, *]
     */
-  implicit def instance[F[_], S, E](implicit
-      monad0: Monad[F]
-  ): Entity[EntityT[F, S, E, *], S, E] =
-    new EntityTLiftInstance[F, S, E] {
-      override protected implicit def monad: Monad[F] = monad0
-    }
+  implicit def instance[F[_]: Monad, S, E]
+      : Entity[EntityT[F, S, E, *], S, E] with Monad[EntityT[F, S, E, *]] =
+    new EntityTLiftInstance[F, S, E]
 }

--- a/core/src/main/scala/endless/core/interpret/EntityTLiftInstance.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityTLiftInstance.scala
@@ -9,33 +9,42 @@ import cats.syntax.flatMap._
 import cats.syntax.functor._
 import endless.core.entity.Entity
 
-trait EntityTLiftInstance[F[_], S, E] extends Entity[EntityT[F, S, E, *], S, E] {
-  protected implicit def monad: Monad[F]
+class EntityTLiftInstance[F[_], S, E](implicit fMonad: Monad[F])
+    extends Entity[EntityT[F, S, E, *], S, E]
+    with Monad[EntityT[F, S, E, *]] {
+  implicit lazy val monad: Monad[EntityT[F, S, E, *]] = new Monad[EntityT[F, S, E, *]] {
+    def pure[A](x: A): EntityT[F, S, E, A] = EntityT.purr(x)
+
+    def flatMap[A, B](fa: EntityT[F, S, E, A])(f: A => EntityT[F, S, E, B]): EntityT[F, S, E, B] =
+      fa.flatMap(f)
+
+    def tailRecM[A, B](a: A)(f: A => EntityT[F, S, E, Either[A, B]]): EntityT[F, S, E, B] =
+      new EntityT[F, S, E, B]((folder, events) =>
+        fMonad.tailRecM((events, a)) { case (events, a) =>
+          f(a).runAcc(folder, events).flatMap {
+            case Right((nextEvents, Left(nextA))) =>
+              f(nextA).runAcc(folder, nextEvents).map {
+                case Right((nextNextEvents, Left(a))) =>
+                  (nextNextEvents, a).asLeft // we keep digging
+                case Right((nextNextEvents, Right(b))) => (nextNextEvents, b).asRight.asRight
+                case Left(invalidFoldReason)           => invalidFoldReason.asLeft.asRight
+              }
+            case Right((nextEvents, Right(b))) => (nextEvents, b).asRight.asRight.pure[F]
+            case Left(invalidFoldReason)       => invalidFoldReason.asLeft.asRight.pure[F]
+          }
+        }
+      )
+  }
+
   override def read: EntityT[F, S, E, Option[S]] = EntityT.reader[F, S, E]
-
-  def pure[A](a: A): EntityT[F, S, E, A] = EntityT.purr(a)
-
   override def write(event: E, other: E*): EntityT[F, S, E, Unit] =
     EntityT.writer(NonEmptyChain(event, other: _*))
 
-  override def flatMap[A, B](fa: EntityT[F, S, E, A])(
-      f: A => EntityT[F, S, E, B]
-  ): EntityT[F, S, E, B] = fa.flatMap(f)
+  def pure[A](x: A): EntityT[F, S, E, A] = monad.pure(x)
+
+  def flatMap[A, B](fa: EntityT[F, S, E, A])(f: A => EntityT[F, S, E, B]): EntityT[F, S, E, B] =
+    monad.flatMap(fa)(f)
 
   def tailRecM[A, B](a: A)(f: A => EntityT[F, S, E, Either[A, B]]): EntityT[F, S, E, B] =
-    new EntityT[F, S, E, B]((folder, events) =>
-      monad.tailRecM((events, a)) { case (events, a) =>
-        f(a).runAcc(folder, events).flatMap {
-          case Right((nextEvents, Left(nextA))) =>
-            f(nextA).runAcc(folder, nextEvents).map {
-              case Right((nextNextEvents, Left(a))) => (nextNextEvents, a).asLeft // we keep digging
-              case Right((nextNextEvents, Right(b))) => (nextNextEvents, b).asRight.asRight
-              case Left(invalidFoldReason)           => invalidFoldReason.asLeft.asRight
-            }
-          case Right((nextEvents, Right(b))) => (nextEvents, b).asRight.asRight.pure
-          case Left(invalidFoldReason)       => invalidFoldReason.asLeft.asRight.pure
-        }
-      }
-    )
-
+    monad.tailRecM(a)(f)
 }

--- a/core/src/main/scala/endless/core/interpret/RepositoryT.scala
+++ b/core/src/main/scala/endless/core/interpret/RepositoryT.scala
@@ -2,59 +2,37 @@ package endless.core.interpret
 
 import cats.tagless.FunctorK
 import cats.tagless.implicits._
-import endless.core.data.Folded
 import endless.core.entity.Repository
-import endless.core.event.EventApplier
-import endless.core.protocol.{CommandProtocol, CommandRouter, IncomingCommand}
+import endless.core.protocol.{CommandProtocol, CommandRouter}
 
-/** `RepositoryT[F, S, E, ID, Alg]` is a data type implementing the `Repository[F, ID, Alg]` entity
-  * access ability.
+/** `RepositoryT[F, ID, Alg]` is a data type implementing the `Repository[F, ID, Alg]` entity access
+  * ability.
   *
   * It assembles the client command protocol together with the command router natural transformation
   * on `OutgoingCommand[*]` to deliver an instance of `Alg[F]` allowing to interact with the
   * specific entity in the cluster.
   *
-  * For the server-side it provides capability of running an incoming command via interpretation of
-  * the algebra with `EntityT`.
-  *
-  * @param entity
-  *   interpreted command handler entity algebra
   * @param commandProtocol
   *   command protocol used to issue commands to entities in the cluster
   * @param commandRouter
   *   command routing natural transformation
-  * @param eventApplier
-  *   event application function
   * @tparam F
   *   context
-  * @tparam S
-  *   state
-  * @tparam E
-  *   event
   * @tparam ID
   *   entity id
   * @tparam Alg
   *   entity algebra
   */
-final class RepositoryT[F[_], S, E, ID, Alg[_[_]]: FunctorK](implicit
-    entity: Alg[EntityT[F, S, E, *]],
+final class RepositoryT[F[_], ID, Alg[_[_]]: FunctorK](implicit
     commandProtocol: CommandProtocol[Alg],
-    commandRouter: CommandRouter[F, ID],
-    eventApplier: EventApplier[S, E]
+    commandRouter: CommandRouter[F, ID]
 ) extends Repository[F, ID, Alg] {
   def entityFor(id: ID): Alg[F] = commandProtocol.client.mapK(commandRouter.routerForID(id))
-
-  def runCommand(
-      state: Option[S],
-      command: IncomingCommand[EntityT[F, S, E, *], Alg]
-  ): F[Folded[E, command.Reply]] = command.runWith(entity).run(state)
 }
 
 object RepositoryT {
-  implicit def apply[F[_], S, E, ID, Alg[_[_]]: FunctorK](implicit
-      entity: Alg[EntityT[F, S, E, *]],
+  implicit def apply[F[_], ID, Alg[_[_]]: FunctorK](implicit
       commandProtocol: CommandProtocol[Alg],
-      commandRouter: CommandRouter[F, ID],
-      applier: EventApplier[S, E]
-  ): RepositoryT[F, S, E, ID, Alg] = new RepositoryT
+      commandRouter: CommandRouter[F, ID]
+  ): RepositoryT[F, ID, Alg] = new RepositoryT
 }

--- a/core/src/test/scala/endless/core/interpret/DurableEntityTSuite.scala
+++ b/core/src/test/scala/endless/core/interpret/DurableEntityTSuite.scala
@@ -1,0 +1,174 @@
+package endless.core.interpret
+
+import cats.laws.discipline.MonadTests
+import cats.syntax.eq._
+import cats.syntax.flatMap._
+import cats.tests.ListWrapper
+import cats.tests.ListWrapper._
+import cats.{Applicative, Eq, Functor, Monad}
+import endless.core.interpret.DurableEntityT._
+import munit.DisciplineSuite
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary._
+import org.typelevel.log4cats.Logger
+
+class DurableEntityTSuite extends DisciplineSuite {
+  type SampleState = String
+  type Value = Int
+  val sampleState: SampleState = "foo"
+
+  implicit val listWrapperMonad: Monad[ListWrapper] = ListWrapper.monad
+
+  // check if resolves
+  Functor[DurableEntityT[ListWrapper, SampleState, *]]
+  Applicative[DurableEntityT[ListWrapper, SampleState, *]]
+  Monad[DurableEntityT[ListWrapper, SampleState, *]]
+
+  implicit def eq: Eq[DurableEntityT.State[SampleState]] =
+    (x: State[SampleState], y: State[SampleState]) =>
+      (x, y) match {
+        case (State.None, State.None)               => true
+        case (State.Existing(a), State.Existing(b)) => a === b
+        case (State.Updated(a), State.Updated(b))   => a === b
+        case (_, _)                                 => false
+      }
+
+  implicit def eqDurableEntityT[A: Eq]: Eq[DurableEntityT[ListWrapper, SampleState, A]] =
+    (
+        x: DurableEntityT[ListWrapper, SampleState, A],
+        y: DurableEntityT[ListWrapper, SampleState, A]
+    ) =>
+      x.run(State.None) === y.run(State.None) &&
+        x.run(State.Existing(sampleState)) === y.run(State.Existing(sampleState)) &&
+        x.run(State.Updated(sampleState)) === y.run(State.Updated(sampleState))
+
+  implicit def arbitrary[F[_]: Monad, A](implicit
+      F: Arbitrary[F[A]]
+  ): Arbitrary[DurableEntityT[F, SampleState, A]] = Arbitrary(
+    F.arbitrary.map(
+      DurableEntityT.stateWriter(sampleState)(Applicative[F]) >> DurableEntityT.liftF(_)
+    )
+  )
+
+  checkAll(
+    "DurableEntityT.MonadLaws",
+    MonadTests[DurableEntityT[ListWrapper, SampleState, *]].monad[Value, Value, Value]
+  )
+
+  test("stateReader returns state") {
+    assertEquals(
+      DurableEntityT
+        .stateReader[ListWrapper, SampleState]
+        .runA(State.None)
+        .list
+        .head,
+      None
+    )
+    assertEquals(
+      DurableEntityT
+        .stateReader[ListWrapper, SampleState]
+        .runA(State.Existing(sampleState))
+        .list
+        .head,
+      Some(sampleState)
+    )
+    assertEquals(
+      DurableEntityT
+        .stateReader[ListWrapper, SampleState]
+        .runA(State.Updated(sampleState))
+        .list
+        .head,
+      Some(sampleState)
+    )
+  }
+
+  test("stateWriter writes state") {
+    assertEquals(
+      DurableEntityT
+        .stateWriter[ListWrapper, SampleState](sampleState)
+        .runS(State.None)
+        .list
+        .head,
+      State.Updated(sampleState)
+    )
+  }
+
+  test("stateModifier modifies state, if possible") {
+    assertEquals(
+      DurableEntityT
+        .stateModifier[ListWrapper, SampleState](
+          _.drop(1)
+        )
+        .runS(State.None)
+        .list
+        .head,
+      State.None
+    )
+    assertEquals(
+      DurableEntityT
+        .stateModifier[ListWrapper, SampleState](
+          _.drop(1)
+        )
+        .runS(State.Existing(sampleState))
+        .list
+        .head,
+      State.Updated(sampleState.drop(1))
+    )
+    assertEquals(
+      DurableEntityT
+        .stateModifier[ListWrapper, SampleState](
+          _.drop(1)
+        )
+        .runS(State.Updated(sampleState))
+        .list
+        .head,
+      State.Updated(sampleState.drop(1))
+    )
+  }
+
+  test("stateModifierF modifies state, if possible") {
+    assertEquals(
+      DurableEntityT
+        .stateModifierF[ListWrapper, SampleState](state =>
+          Applicative[ListWrapper].pure(state.drop(1))
+        )
+        .runS(State.None)
+        .list
+        .head,
+      State.None
+    )
+    assertEquals(
+      DurableEntityT
+        .stateModifierF[ListWrapper, SampleState](state =>
+          Applicative[ListWrapper].pure(state.drop(1))
+        )
+        .runS(State.Existing(sampleState))
+        .list
+        .head,
+      State.Updated(sampleState.drop(1))
+    )
+    assertEquals(
+      DurableEntityT
+        .stateModifierF[ListWrapper, SampleState](state =>
+          Applicative[ListWrapper].pure(state.drop(1))
+        )
+        .runS(State.Updated(sampleState))
+        .list
+        .head,
+      State.Updated(sampleState.drop(1))
+    )
+  }
+
+  test("unit returns unit") {
+    assertEquals(
+      DurableEntityT.unit[ListWrapper, SampleState].runA(State.None).list.head,
+      ()
+    )
+  }
+
+  test("liftK is resolved by Logger auto-derive") {
+    implicit val logger: Logger[ListWrapper] = new DummyTestLogger
+    class SomeLoggingAlgebra[F[_]: Logger]
+    new SomeLoggingAlgebra[DurableEntityT[ListWrapper, SampleState, *]]
+  }
+}

--- a/documentation/src/main/paradox/abstractions.md
+++ b/documentation/src/main/paradox/abstractions.md
@@ -10,6 +10,7 @@ All definitions make use of the following type parameters:
 @@@ index
 * [Repository](repository.md)
 * [Entity](entity.md)
+* [DurableEntity](durable-entity.md)
 * [EventApplier](applier.md)
 * [CommandProtocol](protocol.md)
 * [CommandRouter](router.md)

--- a/documentation/src/main/paradox/durable-entity.md
+++ b/documentation/src/main/paradox/durable-entity.md
@@ -1,0 +1,29 @@
+# Durable entity
+
+```scala
+trait StateReader[F[_], S] {
+  def read: F[S]
+}
+trait StateWriter[F[_], S] {
+  def write(s: S): F[Unit]
+  def modify(f: S => S): F[Unit]
+  def modifyF(f: S => F[S]): F[Unit]
+}
+trait DurableEntity[F[_], S]
+    extends StateReader[F, S]
+    with StateWriter[F, S]
+```
+
+@scaladoc[DurableEntity](endless.core.entity.DurableEntity) is parametrized with entity state `S`. It is a typeclass which represents reader-writer capabilities for `F` with direct state persistence semantics, i.e., the ability to store the full state after processing each command instead of a sequence of events.
+
+For some use cases, e.g. in scenarios with high-frequency updates where each individual update doesn't carry valuable meaning to the domain, events aren't relevant and flashing the full state is preferable.
+
+Such "durable" entities still benefit from sharding, passivation, rebalancing, automatic recovery etc. while keeping the persistence model simple. In effect, this is a way to implement CRUD-like distributed entities while retaining the advantages of actors, such as the ability to actively schedule side-effects, precise state-machine semantics, consistent distributed in-memory state, etc.   
+
+@@@ Note
+`DurableEntity` is the equivalent of [`Stateful`](https://typelevel.org/cats-mtl/mtl-classes/stateful.html) in cats MTL, with the additional persistence semantics
+@@@
+
+@@@ tip { title="Event-sourcing" }
+For the equivalent abstraction with event-sourcing abilities, see @ref:[DurableEntity](entity.md)
+@@@

--- a/documentation/src/main/paradox/entity.md
+++ b/documentation/src/main/paradox/entity.md
@@ -7,10 +7,10 @@ trait StateReader[F[_], S] {
 trait EventWriter[F[_], E] {
   def write(event: E, other: E*): F[Unit]
 }
-trait Entity[F[_], S, E] extends StateReader[F, S] with EventWriter[F, E] with Monad[F]
+trait Entity[F[_], S, E] extends StateReader[F, S] with EventWriter[F, E]
 ```
 
-@scaladoc[Entity](endless.core.entity.Entity) is parametrized with entity state `S` and events `E`. It is a typeclass which represents reader-writer monad capabilities for `F` with event-sourcing semantics, i.e. the abilities to read current entity state from the context and write events into it. `Entity` is typically used by the entity algebra command handling interpreter (e.g. @github[BookingEntity](/example/src/main/scala/endless/example/logic/BookingEntity.scala)). 
+@scaladoc[Entity](endless.core.entity.Entity) is parametrized with entity state `S` and events `E`. It is a typeclass which represents reader-writer capabilities for `F` with event-sourcing semantics, i.e. the abilities to read current entity state from the context and persist events. `Entity` is typically used by the entity algebra command handling interpreter (e.g. @github[BookingEntity](/example/src/main/scala/endless/example/logic/BookingEntity.scala)). 
 
 ## Functional event sourcing
 *Reader-writer* is a natural fit for describing event sourcing behavior: the monadic chain represents event sequencing and corresponding evolution of the state (see also [here](https://pavkin.ru/aecor-part-2/) and [here](https://www.youtube.com/watch?v=kDkRRkkVlxQ)).
@@ -28,6 +28,10 @@ Advantages of this abstraction are:
 
 @@@ warning { title="Responsivity" }
 When defining event-sourced entities, it is considered best practice to process commands and formulate a reply quickly as it makes the system responsive. Long-running processes should only initiate as the result of events, which also has the added benefit that they can be restored upon recovery or be driven by a projection. See @ref:[Effector](effector.md) to find out how to describe side effects with *endless*.  
+@@@
+
+@@@ tip { title="Event-less persistence" }
+It is also possible to benefit from cluster sharding without involving event-sourcing, see @ref:[DurableEntity](durable-entity.md)
 @@@
 
 @@@ note { title="About performance" }

--- a/documentation/src/main/paradox/example.md
+++ b/documentation/src/main/paradox/example.md
@@ -1,14 +1,14 @@
 # Example app
 
-Endless example application is a small API for managing imaginary bookings for passenger trips from some origin to some destination. It can be found in `endless-example` and can be run directly: `sbt run`. 
+Endless example application is a small API for managing imaginary bookings for passenger trips from some origin to some destination, as well as tracking positions and speeds of vehicles. It can be found in `endless-example` and can be run directly: `sbt run`. 
 
 ## API
-It has a simple CRUD API for those bookings:
+It has a simple CRUD API for bookings and vehicles:
 
 @@snip [ExampleApp](/example/src/main/scala/endless/example/ExampleApp.scala) { #api }
 
 ## Scaffolding
-The application is assembled via a call to @scaladoc[deployEntity](endless.runtime.akka.Deployer.deployEntity) (see @ref:[runtime](runtime.md) for more details)
+The application is assembled via calls to @scaladoc[deployEntity](endless.runtime.akka.Deployer.deployEntity) (for bookings) and @scaladoc[deployDurableEntity](endless.runtime.akka.Deployer.deployDurableEntity) (for vehicles) (see @ref:[runtime](runtime.md) for more details)
 
 @@snip [ExampleApp](/example/src/main/scala/endless/example/ExampleApp.scala) { #main }
 

--- a/documentation/src/main/paradox/index.md
+++ b/documentation/src/main/paradox/index.md
@@ -1,6 +1,6 @@
 <center><img src="logo.svg" width="350"/></center>
 
-endless is a Scala library to describe event sourced entities using tagless-final algebras, running with built-in implementations for Akka.
+endless is a Scala library to describe sharded and event sourced entities using tagless-final algebras, running with built-in implementations for Akka.
 
 
 @@@ note { .quote title="/ˈɛndləs/: having or seeming to have no end or limit" }

--- a/documentation/src/main/paradox/nutshell.md
+++ b/documentation/src/main/paradox/nutshell.md
@@ -5,7 +5,7 @@
 Implementations for various aspects of an entity are provided via abstract interpreters making use of endless [*typeclasses*](https://en.wikipedia.org/wiki/Type_class):
 
  - @ref:[Repository](repository.md): represents the ability to interact with a specific entity in the cluster
- - @ref:[Entity](entity.md): ability to process a command by reading the state, writing events affecting the state and producing a reply
+ - @ref:[Entity](entity.md): ability to process a command by reading the state, writing events affecting the state and producing a reply (direct state persistence is supported with @ref:[DurableEntity](durable-entity.md))
  - @ref:[EventApplier](applier.md): ability to [*fold*](https://en.wikipedia.org/wiki/Fold_\(higher-order_function\)) events over entity state
  - @ref:[CommandProtocol](protocol.md): ability to translate entity algebra invocations into serializable commands and replies
  - @ref:[Effector](effector.md): ability to produce side effects after event persistence, including passivation of the entity itself

--- a/documentation/src/main/paradox/runtime.md
+++ b/documentation/src/main/paradox/runtime.md
@@ -21,6 +21,10 @@ In order to bridge Akka's implicit asynchronicity with the side-effect free cont
 `deployEntity` needs to be called upon application startup, before joining the cluster as the `ClusterSharding` extension needs to know about the various entity types beforehand.
 @@@
 
+@@@ note { title="Durable entity" }
+ The equivalent method for durable entities is @scaladoc[deployDurableEntity](endless.runtime.akka.DurableDeployer).
+@@@
+
 ## Internals
 
 ### Protocol
@@ -28,7 +32,7 @@ Thanks to the @ref:[CommandProtocol](protocol.md) instance, entity algebra calls
 [ShardingCommandRouter](/runtime/src/main/scala/endless/runtime/akka/ShardingCommandRouter.scala) takes care of delivering the commands to the right entity and returning the reply simply by using Akka's `ask`.
 
 ### Deployer
-Internally, @github[deployEntity](/runtime/src/main/scala/endless/runtime/akka/Deployer.scala) uses Akka @link:[EventSourcedBehavior](https://doc.akka.io/docs/akka/current/typed/persistence.html#example-and-core-api) { open=new } DSL to configure the entity in the following way:
+Internally, @github[deployEntity](/runtime/src/main/scala/endless/runtime/akka/Deployer.scala) uses Akka @link:[EventSourcedBehavior](https://doc.akka.io/docs/akka/current/typed/persistence.html#example-and-core-api) { open=new } DSL to configure the entity in the following way (for @github[deployDurableEntity](/runtime/src/main/scala/endless/runtime/akka/DurableDeployer.scala), this is [DurableStateBehavior](https://doc.akka.io/docs/akka/current/typed/durable-state/persistence.html#example-and-core-api)):
 
 #### Command handler
 

--- a/example/src/main/protobuf/vehicle/commands.proto
+++ b/example/src/main/protobuf/vehicle/commands.proto
@@ -1,0 +1,24 @@
+syntax = "proto3";
+
+package endless.example.proto.vehicle;
+
+import "scalapb/scalapb.proto";
+import "vehicle/models.proto";
+
+message VehicleCommand {
+  oneof command {
+    SetSpeedV1Full set_speed_v1 = 1;
+    SetPositionV1Full set_position_v1 = 2;
+    GetSpeedV1Full get_speed_v1 = 3;
+    GetPositionV1Full get_position_v1 = 4;
+  }
+}
+
+message SetSpeedV1Full {
+  SpeedV1Full speed = 1             [(scalapb.field).required = true];
+}
+message SetPositionV1Full {
+  LatLonV1Full position = 1         [(scalapb.field).required = true];
+}
+message GetSpeedV1Full {}
+message GetPositionV1Full {}

--- a/example/src/main/protobuf/vehicle/models.proto
+++ b/example/src/main/protobuf/vehicle/models.proto
@@ -1,0 +1,12 @@
+syntax = "proto3";
+
+package endless.example.proto.vehicle;
+
+message SpeedV1Full {
+  double metersPerSecond = 1;
+}
+
+message LatLonV1Full {
+  double lat = 1;
+  double lon = 2;
+}

--- a/example/src/main/protobuf/vehicle/replies.proto
+++ b/example/src/main/protobuf/vehicle/replies.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package endless.example.proto.vehicle;
+
+import "vehicle/models.proto";
+
+message UnitReply {}
+
+message GetSpeedV1FullReply {
+  SpeedV1Full speed = 1;
+}
+
+message GetPositionV1FullReply {
+  LatLonV1Full position = 1;
+}

--- a/example/src/main/protobuf/vehicle/state.proto
+++ b/example/src/main/protobuf/vehicle/state.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package endless.example.proto.vehicle;
+
+import "vehicle/models.proto";
+
+message VehicleStateV1Full {
+  LatLonV1Full position = 1;
+  SpeedV1Full speed = 2;
+}

--- a/example/src/main/resources/application.conf
+++ b/example/src/main/resources/application.conf
@@ -1,12 +1,12 @@
 cluster {
-  system-name = "bookings-as"
+  system-name = "example-as"
   host = "127.0.0.1"
   port = 51000
 }
 
 akka {
-  loglevel = "debug"
-  stdout-loglevel = "debug"
+  loglevel = "info"
+  stdout-loglevel = "info"
   loggers = ["akka.event.slf4j.Slf4jLogger"]
   logging-filter = "akka.event.slf4j.Slf4jLoggingFilter"
   actor {
@@ -14,10 +14,15 @@ akka {
     allow-java-serialization = off
     serialize-messages = on
     serializers {
-      event-serializer = "endless.example.serializer.BookingEventSerializer"
+      booking-event-serializer = "endless.example.serializer.BookingEventSerializer"
+      scalapb-serializer = "endless.protobuf.ScalaPbSerializer"
+    }
+    serialization-identifiers {
+      "endless.protobuf.ScalaPbSerializer" = 424242
     }
     serialization-bindings {
-      "endless.example.data.BookingEvent" = event-serializer
+      "endless.example.data.BookingEvent" = booking-event-serializer
+      "endless.example.proto.vehicle.state.VehicleStateV1Full" = scalapb-serializer
     }
   }
   remote {

--- a/example/src/main/scala/endless/example/Main.scala
+++ b/example/src/main/scala/endless/example/Main.scala
@@ -1,7 +1,10 @@
 package endless.example
 
 import akka.actor.typed.ActorSystem
-import akka.persistence.testkit.PersistenceTestKitPlugin
+import akka.persistence.testkit.{
+  PersistenceTestKitDurableStateStorePlugin,
+  PersistenceTestKitPlugin
+}
 import cats.effect._
 import com.typesafe.config.ConfigFactory
 
@@ -9,8 +12,11 @@ object Main extends IOApp {
   implicit val actorSystem: ActorSystem[Nothing] =
     ActorSystem.wrap(
       akka.actor.ActorSystem(
-        "bookings-as",
-        PersistenceTestKitPlugin.config.withFallback(ConfigFactory.defaultApplication).resolve()
+        "example-as",
+        PersistenceTestKitPlugin.config
+          .withFallback(PersistenceTestKitDurableStateStorePlugin.config)
+          .withFallback(ConfigFactory.defaultApplication)
+          .resolve()
       )
     )
 

--- a/example/src/main/scala/endless/example/adapter/VehicleStateAdapter.scala
+++ b/example/src/main/scala/endless/example/adapter/VehicleStateAdapter.scala
@@ -1,0 +1,23 @@
+package endless.example.adapter
+
+import akka.persistence.typed.SnapshotAdapter
+import endless.example.data.{LatLon, Speed, Vehicle}
+import endless.example.proto.vehicle.models.{LatLonV1Full, SpeedV1Full}
+import endless.example.proto.vehicle.state.VehicleStateV1Full
+
+class VehicleStateAdapter extends SnapshotAdapter[Option[Vehicle]] {
+  def toJournal(state: Option[Vehicle]): Any = VehicleStateV1Full(
+    state.flatMap(_.position.map(latLon => LatLonV1Full(latLon.lat, latLon.lon))),
+    state.flatMap(_.speed.map(s => SpeedV1Full(s.metersPerSecond)))
+  )
+
+  def fromJournal(from: Any): Option[Vehicle] = from match {
+    case VehicleStateV1Full(position, speed, _) =>
+      Some(
+        Vehicle(
+          position.map(latLon => LatLon(latLon.lat, latLon.lon)),
+          speed.map(_.metersPerSecond).map(Speed(_))
+        )
+      )
+  }
+}

--- a/example/src/main/scala/endless/example/algebra/BookingAlg.scala
+++ b/example/src/main/scala/endless/example/algebra/BookingAlg.scala
@@ -3,8 +3,8 @@ package endless.example.algebra
 import cats.tagless.{Derive, FunctorK}
 import endless.\/
 import endless.example.algebra.BookingAlg.{BookingAlreadyExists, BookingUnknown, CancelError}
-import endless.example.data.Booking
-import endless.example.data.Booking.{BookingID, LatLon}
+import endless.example.data.Booking.BookingID
+import endless.example.data.{Booking, LatLon}
 
 import java.time.Instant
 

--- a/example/src/main/scala/endless/example/algebra/VehicleAlg.scala
+++ b/example/src/main/scala/endless/example/algebra/VehicleAlg.scala
@@ -1,0 +1,17 @@
+package endless.example.algebra
+
+import cats.tagless.{Derive, FunctorK}
+import endless.example.data.{LatLon, Speed}
+
+//#definition
+trait VehicleAlg[F[_]] {
+  def setSpeed(speed: Speed): F[Unit]
+  def setPosition(position: LatLon): F[Unit]
+  def getSpeed: F[Option[Speed]]
+  def getPosition: F[Option[LatLon]]
+}
+//#definition
+
+object VehicleAlg {
+  implicit lazy val functorKInstance: FunctorK[VehicleAlg] = Derive.functorK[VehicleAlg]
+}

--- a/example/src/main/scala/endless/example/algebra/VehicleRepositoryAlg.scala
+++ b/example/src/main/scala/endless/example/algebra/VehicleRepositoryAlg.scala
@@ -1,0 +1,9 @@
+package endless.example.algebra
+
+import endless.example.data.Vehicle.VehicleID
+
+//#definition
+trait VehicleRepositoryAlg[F[_]] {
+  def vehicleFor(vehicleID: VehicleID): VehicleAlg[F]
+}
+//#definition

--- a/example/src/main/scala/endless/example/data/Booking.scala
+++ b/example/src/main/scala/endless/example/data/Booking.scala
@@ -1,6 +1,6 @@
 package endless.example.data
 
-import cats.{Eq, Show}
+import cats.Show
 import endless.example.data.Booking._
 
 import java.time.Instant
@@ -20,10 +20,6 @@ object Booking {
   object BookingID {
     def fromString(str: String): BookingID = BookingID(UUID.fromString(str))
     implicit val show: Show[BookingID] = Show.show(_.id.toString)
-  }
-  final case class LatLon(lat: Double, lon: Double)
-  object LatLon {
-    implicit val eq: Eq[LatLon] = Eq.fromUniversalEquals
   }
   sealed trait Status
   object Status {

--- a/example/src/main/scala/endless/example/data/BookingEvent.scala
+++ b/example/src/main/scala/endless/example/data/BookingEvent.scala
@@ -1,6 +1,6 @@
 package endless.example.data
 
-import endless.example.data.Booking.{BookingID, LatLon}
+import endless.example.data.Booking.BookingID
 
 import java.time.Instant
 

--- a/example/src/main/scala/endless/example/data/LatLon.scala
+++ b/example/src/main/scala/endless/example/data/LatLon.scala
@@ -1,0 +1,13 @@
+package endless.example.data
+
+import cats.Show
+import cats.kernel.Eq
+import cats.syntax.show._
+
+final case class LatLon(lat: Double, lon: Double)
+
+object LatLon {
+  implicit val eq: Eq[LatLon] = Eq.fromUniversalEquals
+  implicit val show: Show[LatLon] =
+    Show.show(latLon => show"[lat=${latLon.lat}, lon=${latLon.lon}]")
+}

--- a/example/src/main/scala/endless/example/data/Speed.scala
+++ b/example/src/main/scala/endless/example/data/Speed.scala
@@ -1,0 +1,10 @@
+package endless.example.data
+
+import cats.Show
+import cats.syntax.show._
+
+final case class Speed(metersPerSecond: Double) extends AnyVal
+
+object Speed {
+  implicit val show: Show[Speed] = Show.show(speed => show"${speed.metersPerSecond} m/s")
+}

--- a/example/src/main/scala/endless/example/data/Vehicle.scala
+++ b/example/src/main/scala/endless/example/data/Vehicle.scala
@@ -1,0 +1,15 @@
+package endless.example.data
+
+import cats.Show
+
+import java.util.UUID
+
+final case class Vehicle(position: Option[LatLon], speed: Option[Speed])
+
+object Vehicle {
+  final case class VehicleID(id: UUID) extends AnyVal
+  object VehicleID {
+    def fromString(str: String): VehicleID = VehicleID(UUID.fromString(str))
+    implicit val show: Show[VehicleID] = Show.show(_.id.toString)
+  }
+}

--- a/example/src/main/scala/endless/example/logic/BookingEntity.scala
+++ b/example/src/main/scala/endless/example/logic/BookingEntity.scala
@@ -1,6 +1,5 @@
 package endless.example.logic
 
-import cats.Monad
 import cats.data.EitherT
 import cats.syntax.applicative._
 import cats.syntax.eq._
@@ -12,13 +11,13 @@ import endless.example.algebra.BookingAlg
 import endless.example.algebra.BookingAlg.{BookingAlreadyExists, BookingUnknown, CancelError}
 import endless.example.data.Booking._
 import endless.example.data.BookingEvent._
-import endless.example.data.{Booking, BookingEvent}
+import endless.example.data.{Booking, BookingEvent, LatLon}
 import org.typelevel.log4cats.Logger
 
 import java.time.Instant
 
 //#definition
-final case class BookingEntity[F[_]: Monad: Logger](entity: Entity[F, Booking, BookingEvent])
+final case class BookingEntity[F[_]: Logger](entity: Entity[F, Booking, BookingEvent])
     extends BookingAlg[F] {
   import entity._
 

--- a/example/src/main/scala/endless/example/logic/BookingRepository.scala
+++ b/example/src/main/scala/endless/example/logic/BookingRepository.scala
@@ -8,7 +8,6 @@ import endless.example.data.Booking.BookingID
 //#definition
 final case class BookingRepository[F[_]: Monad](repository: Repository[F, BookingID, BookingAlg])
     extends BookingRepositoryAlg[F] {
-  import repository._
-  def bookingFor(bookingID: BookingID): BookingAlg[F] = entityFor(bookingID)
+  def bookingFor(bookingID: BookingID): BookingAlg[F] = repository.entityFor(bookingID)
 }
 //#definition

--- a/example/src/main/scala/endless/example/logic/VehicleEntity.scala
+++ b/example/src/main/scala/endless/example/logic/VehicleEntity.scala
@@ -1,0 +1,38 @@
+package endless.example.logic
+
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.show._
+import endless.core.entity.DurableEntity
+import endless.example.algebra.VehicleAlg
+import endless.example.data.{LatLon, Speed, Vehicle}
+import org.typelevel.log4cats.Logger
+
+final case class VehicleEntity[F[_]: Logger](entity: DurableEntity[F, Vehicle])
+    extends VehicleAlg[F] {
+  import entity._
+
+  def setSpeed(speed: Speed): F[Unit] =
+    ifKnownElse(_ =>
+      Logger[F].info(show"Update speed to $speed") >> modify(_.copy(speed = Some(speed)))
+    )(
+      Logger[F].info(show"New vehicle with speed $speed") >> write(
+        Vehicle(position = None, Some(speed))
+      )
+    )
+
+  def setPosition(position: LatLon): F[Unit] =
+    ifKnownElse(_ =>
+      Logger[F].info(show"Update position to $position") >> modify(
+        _.copy(position = Some(position))
+      )
+    )(
+      Logger[F].info(show"New vehicle with position $position") >> write(
+        Vehicle(position = Some(position), None)
+      )
+    )
+
+  def getSpeed: F[Option[Speed]] = read.map(_.flatMap(_.speed))
+
+  def getPosition: F[Option[LatLon]] = read.map(_.flatMap(_.position))
+}

--- a/example/src/main/scala/endless/example/logic/VehicleRepository.scala
+++ b/example/src/main/scala/endless/example/logic/VehicleRepository.scala
@@ -1,0 +1,11 @@
+package endless.example.logic
+
+import cats.Monad
+import endless.core.entity.Repository
+import endless.example.algebra.{VehicleAlg, VehicleRepositoryAlg}
+import endless.example.data.Vehicle.VehicleID
+
+final case class VehicleRepository[F[_]: Monad](repository: Repository[F, VehicleID, VehicleAlg])
+    extends VehicleRepositoryAlg[F] {
+  def vehicleFor(vehicleID: VehicleID): VehicleAlg[F] = repository.entityFor(vehicleID)
+}

--- a/example/src/main/scala/endless/example/protocol/BookingCommand.scala
+++ b/example/src/main/scala/endless/example/protocol/BookingCommand.scala
@@ -1,6 +1,7 @@
 package endless.example.protocol
 
-import endless.example.data.Booking.{BookingID, LatLon}
+import endless.example.data.Booking.BookingID
+import endless.example.data.LatLon
 
 import java.time.Instant
 

--- a/example/src/main/scala/endless/example/protocol/BookingCommandProtocol.scala
+++ b/example/src/main/scala/endless/example/protocol/BookingCommandProtocol.scala
@@ -5,8 +5,8 @@ import endless.circe.{CirceCommandProtocol, CirceDecoder}
 import endless.core.protocol.{Decoder, IncomingCommand, OutgoingCommand}
 import endless.example.algebra.BookingAlg
 import endless.example.algebra.BookingAlg.{BookingAlreadyExists, BookingUnknown, CancelError}
-import endless.example.data.Booking
-import endless.example.data.Booking.{BookingID, LatLon}
+import endless.example.data.Booking.BookingID
+import endless.example.data.{Booking, LatLon}
 import endless.example.protocol.BookingCommand._
 import io.circe.generic.auto._
 

--- a/example/src/main/scala/endless/example/protocol/VehicleCommandProtocol.scala
+++ b/example/src/main/scala/endless/example/protocol/VehicleCommandProtocol.scala
@@ -1,0 +1,76 @@
+package endless.example.protocol
+
+import endless.core.protocol.{Decoder, IncomingCommand, OutgoingCommand}
+import endless.example.algebra.VehicleAlg
+import endless.example.data.{LatLon, Speed}
+import endless.example.proto.vehicle.commands.VehicleCommand.Command
+import endless.example.proto.vehicle.commands._
+import endless.example.proto.vehicle.models.{LatLonV1Full, SpeedV1Full}
+import endless.example.proto.vehicle.replies.{GetPositionV1FullReply, GetSpeedV1FullReply, UnitReply}
+import endless.example.protocol.VehicleCommandProtocol.UnexpectedCommandException
+import endless.protobuf.{ProtobufCommandProtocol, ProtobufDecoder}
+
+class VehicleCommandProtocol extends ProtobufCommandProtocol[VehicleAlg] {
+  def server[F[_]]: Decoder[IncomingCommand[F, VehicleAlg]] =
+    ProtobufDecoder[VehicleCommand].map(_.command match {
+      case Command.Empty => throw new UnexpectedCommandException
+      case Command.SetSpeedV1(value) =>
+        incomingCommand[F, UnitReply, Unit](
+          _.setSpeed(Speed(value.speed.metersPerSecond)),
+          _ => UnitReply()
+        )
+      case Command.SetPositionV1(value) =>
+        incomingCommand[F, UnitReply, Unit](
+          _.setPosition(LatLon(value.position.lat, value.position.lon)),
+          _ => UnitReply()
+        )
+      case Command.GetSpeedV1(_) =>
+        incomingCommand[F, GetSpeedV1FullReply, Option[Speed]](
+          _.getSpeed,
+          maybeSpeed =>
+            GetSpeedV1FullReply.of(maybeSpeed.map(speed => SpeedV1Full.of(speed.metersPerSecond)))
+        )
+      case Command.GetPositionV1(_) =>
+        incomingCommand[F, GetPositionV1FullReply, Option[LatLon]](
+          _.getPosition,
+          maybePosition =>
+            GetPositionV1FullReply.of(
+              maybePosition.map(position => LatLonV1Full.of(position.lat, position.lon))
+            )
+        )
+    })
+
+  def client: VehicleAlg[OutgoingCommand[*]] = new VehicleAlg[OutgoingCommand] {
+    def setSpeed(speed: Speed): OutgoingCommand[Unit] =
+      outgoingCommand[VehicleCommand, UnitReply, Unit](
+        VehicleCommand.of(
+          Command.SetSpeedV1(SetSpeedV1Full.of(SpeedV1Full.of(speed.metersPerSecond)))
+        ),
+        _ => ()
+      )
+
+    def setPosition(position: LatLon): OutgoingCommand[Unit] =
+      outgoingCommand[VehicleCommand, UnitReply, Unit](
+        VehicleCommand.of(
+          Command.SetPositionV1(SetPositionV1Full.of(LatLonV1Full.of(position.lat, position.lon)))
+        ),
+        _ => ()
+      )
+
+    def getSpeed: OutgoingCommand[Option[Speed]] =
+      outgoingCommand[VehicleCommand, GetSpeedV1FullReply, Option[Speed]](
+        VehicleCommand.of(Command.GetSpeedV1(GetSpeedV1Full())),
+        _.speed.map(speed => Speed(speed.metersPerSecond))
+      )
+
+    def getPosition: OutgoingCommand[Option[LatLon]] =
+      outgoingCommand[VehicleCommand, GetPositionV1FullReply, Option[LatLon]](
+        VehicleCommand.of(Command.GetPositionV1(GetPositionV1Full())),
+        _.position.map(position => LatLon(position.lat, position.lon))
+      )
+  }
+}
+
+object VehicleCommandProtocol {
+  final class UnexpectedCommandException extends RuntimeException("Unexpected command")
+}

--- a/example/src/test/resources/logback-test.xml
+++ b/example/src/test/resources/logback-test.xml
@@ -1,0 +1,12 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <charset>utf-8</charset>
+            <pattern>%-20d{dd/MM/YYYY HH:mm:ss.SSS} %-5level %logger - %msg %X{JoinedMdc}%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+      <!-->  <appender-ref ref="STDOUT" /> verbose but keep level for coverage <!-->
+    </root>
+</configuration>

--- a/example/src/test/scala/endless/example/ExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/ExampleAppSuite.scala
@@ -1,15 +1,19 @@
 package endless.example
 
 import akka.actor.typed.ActorSystem
-import akka.persistence.testkit.PersistenceTestKitPlugin
+import akka.persistence.testkit.{
+  PersistenceTestKitDurableStateStorePlugin,
+  PersistenceTestKitPlugin
+}
 import cats.effect.IO
 import cats.effect.kernel.Resource
 import cats.syntax.applicative._
 import cats.syntax.show._
 import com.typesafe.config.ConfigFactory
 import endless.example.ExampleApp._
-import endless.example.data.Booking
-import endless.example.data.Booking.{BookingID, LatLon}
+import endless.example.data.Booking.BookingID
+import endless.example.data.Vehicle.VehicleID
+import endless.example.data.{Booking, LatLon, Speed}
 import io.circe.generic.auto._
 import org.http4s.Method._
 import org.http4s.blaze.client.BlazeClientBuilder
@@ -25,8 +29,11 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
   implicit val actorSystem: ActorSystem[Nothing] =
     ActorSystem.wrap(
       akka.actor.ActorSystem(
-        "bookings-as",
-        PersistenceTestKitPlugin.config.withFallback(ConfigFactory.defaultApplication).resolve()
+        "example-as",
+        PersistenceTestKitPlugin.config
+          .withFallback(PersistenceTestKitDurableStateStorePlugin.config)
+          .withFallback(ConfigFactory.defaultApplication)
+          .resolve()
       )
     )
 
@@ -38,17 +45,19 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
         .flatMap(server => Resource.make(server.pure[IO])(_ => IO.delay(actorSystem.terminate())))
     )
   private val client = ResourceSuiteLocalFixture("booking-client", BlazeClientBuilder[IO].resource)
-  private val baseUri = uri"http://localhost:8080/booking"
+  private val baseUri = uri"http://localhost:8080"
+  private val baseBookingUri = baseUri / "booking"
+  private val baseVehicleUri = baseUri / "vehicle"
 
   override def munitFixtures = List(server, client)
 
-  test("post booking creates booking") {
+  test("POST booking creates booking") {
     val bookingRequest = BookingRequest(Instant.now, 1, LatLon(0, 0), LatLon(1, 1))
     for {
-      bookingID <- client().expect[BookingID](POST(bookingRequest, baseUri))
+      bookingID <- client().expect[BookingID](POST(bookingRequest, baseBookingUri))
       _ <- IO.sleep(1.second)
       _ <- assertIO(
-        client().expect[Booking](GET(baseUri / bookingID.show)),
+        client().expect[Booking](GET(baseBookingUri / bookingID.show)),
         Booking(
           bookingID,
           bookingRequest.time,
@@ -61,22 +70,22 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
     } yield ()
   }
 
-  test("patch booking modifies booking") {
+  test("PATCH booking modifies booking") {
     val bookingRequest = BookingRequest(Instant.now, 2, LatLon(0, 0), LatLon(1, 1))
     for {
-      bookingID <- client().expect[BookingID](POST(bookingRequest, baseUri))
+      bookingID <- client().expect[BookingID](POST(bookingRequest, baseBookingUri))
       _ <- client().status(
-        PATCH(BookingPatch(Some(LatLon(2, 2)), None), baseUri / bookingID.show)
+        PATCH(BookingPatch(Some(LatLon(2, 2)), None), baseBookingUri / bookingID.show)
       )
       _ <- client().status(
-        PATCH(BookingPatch(None, Some(LatLon(3, 3))), baseUri / bookingID.show)
+        PATCH(BookingPatch(None, Some(LatLon(3, 3))), baseBookingUri / bookingID.show)
       )
       _ <- client().status(
-        PATCH(BookingPatch(Some(LatLon(4, 4)), Some(LatLon(5, 5))), baseUri / bookingID.show)
+        PATCH(BookingPatch(Some(LatLon(4, 4)), Some(LatLon(5, 5))), baseBookingUri / bookingID.show)
       )
       _ <- IO.sleep(1.second)
       _ <- assertIO(
-        client().expect[Booking](GET(baseUri / bookingID.show)),
+        client().expect[Booking](GET(baseBookingUri / bookingID.show)),
         Booking(
           bookingID,
           bookingRequest.time,
@@ -90,14 +99,20 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
   }
 
   test("GET booking for unknown ID fails") {
-    assertIO(client().status(GET(baseUri / BookingID(UUID.randomUUID()).show)).map(_.code), 400)
+    assertIO(
+      client().status(GET(baseBookingUri / BookingID(UUID.randomUUID()).show)).map(_.code),
+      400
+    )
   }
 
   test("PATCH booking for unknown ID fails") {
     assertIO(
       client()
         .status(
-          PATCH(BookingPatch(Some(LatLon(1, 1)), None), baseUri / BookingID(UUID.randomUUID()).show)
+          PATCH(
+            BookingPatch(Some(LatLon(1, 1)), None),
+            baseBookingUri / BookingID(UUID.randomUUID()).show
+          )
         )
         .map(_.code),
       400
@@ -107,10 +122,10 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
   test("POST bookingID/cancel cancels booking") {
     val bookingRequest = BookingRequest(Instant.now, 1, LatLon(0, 0), LatLon(1, 1))
     for {
-      bookingID <- client().expect[BookingID](POST(bookingRequest, baseUri))
-      _ <- client().status(POST(baseUri / bookingID.show / "cancel"))
+      bookingID <- client().expect[BookingID](POST(bookingRequest, baseBookingUri))
+      _ <- client().status(POST(baseBookingUri / bookingID.show / "cancel"))
       _ <- assertIO(
-        client().expect[Booking](GET(baseUri / bookingID.show)),
+        client().expect[Booking](GET(baseBookingUri / bookingID.show)),
         Booking(
           bookingID,
           bookingRequest.time,
@@ -127,7 +142,51 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
     assertIO(
       client()
         .status(
-          POST(baseUri / BookingID(UUID.randomUUID()).show / "cancel")
+          POST(baseBookingUri / BookingID(UUID.randomUUID()).show / "cancel")
+        )
+        .map(_.code),
+      400
+    )
+  }
+
+  test("POST several positions & speeds of a vehicle and finally GET them back") {
+    for {
+      vehicleID <- IO.pure(VehicleID(UUID.randomUUID()))
+      _ <- client().status(POST(LatLon(1, 1), baseVehicleUri / vehicleID.show / "position"))
+      _ <- client().status(POST(Speed(1), baseVehicleUri / vehicleID.show / "speed"))
+      _ <- client().status(POST(Speed(2), baseVehicleUri / vehicleID.show / "speed"))
+      _ <- client().status(POST(LatLon(2, 2), baseVehicleUri / vehicleID.show / "position"))
+      _ <- client().status(POST(LatLon(3, 3), baseVehicleUri / vehicleID.show / "position"))
+      _ <- client().status(POST(LatLon(4, 4), baseVehicleUri / vehicleID.show / "position"))
+      _ <- client().status(POST(Speed(0), baseVehicleUri / vehicleID.show / "speed"))
+      _ <- IO.sleep(2.seconds) // passivation occurs
+      _ <- assertIO(
+        client().expect[LatLon](GET(baseVehicleUri / vehicleID.show / "position")),
+        LatLon(4, 4)
+      )
+      _ <- assertIO(
+        client().expect[Speed](GET(baseVehicleUri / vehicleID.show / "speed")),
+        Speed(0)
+      )
+    } yield ()
+  }
+
+  test("GET vehicle position for unknown ID fails") {
+    assertIO(
+      client()
+        .status(
+          GET(baseVehicleUri / VehicleID(UUID.randomUUID()).show / "position")
+        )
+        .map(_.code),
+      400
+    )
+  }
+
+  test("GET vehicle speed for unknown ID fails") {
+    assertIO(
+      client()
+        .status(
+          GET(baseVehicleUri / VehicleID(UUID.randomUUID()).show / "speed")
         )
         .map(_.code),
       400

--- a/example/src/test/scala/endless/example/logic/BookingEffectorSuite.scala
+++ b/example/src/test/scala/endless/example/logic/BookingEffectorSuite.scala
@@ -8,7 +8,7 @@ import endless.\/
 import endless.core.interpret.EffectorT
 import endless.core.interpret.EffectorT._
 import endless.example.algebra.{AvailabilityAlg, BookingAlg}
-import endless.example.data.Booking
+import endless.example.data.{Booking, LatLon}
 import org.scalacheck.effect.PropF._
 import org.typelevel.log4cats.testing.TestingLogger
 
@@ -78,27 +78,25 @@ class BookingEffectorSuite
         bookingID: Booking.BookingID,
         time: Instant,
         passengerCount: Int,
-        origin: Booking.LatLon,
-        destination: Booking.LatLon
+        origin: LatLon,
+        destination: LatLon
     ): IO[BookingAlg.BookingAlreadyExists \/ Unit] =
       IO.raiseError(new RuntimeException("should not be called"))
 
     override def get: IO[BookingAlg.BookingUnknown.type \/ Booking] =
       IO.raiseError(new RuntimeException("should not be called"))
 
-    override def changeOrigin(
-        newOrigin: Booking.LatLon
-    ): IO[BookingAlg.BookingUnknown.type \/ Unit] =
+    override def changeOrigin(newOrigin: LatLon): IO[BookingAlg.BookingUnknown.type \/ Unit] =
       IO.raiseError(new RuntimeException("should not be called"))
 
     override def changeDestination(
-        newDestination: Booking.LatLon
+        newDestination: LatLon
     ): IO[BookingAlg.BookingUnknown.type \/ Unit] =
       IO.raiseError(new RuntimeException("should not be called"))
 
     override def changeOriginAndDestination(
-        newOrigin: Booking.LatLon,
-        newDestination: Booking.LatLon
+        newOrigin: LatLon,
+        newDestination: LatLon
     ): IO[BookingAlg.BookingUnknown.type \/ Unit] =
       IO.raiseError(new RuntimeException("should not be called"))
 

--- a/example/src/test/scala/endless/example/logic/BookingEntitySuite.scala
+++ b/example/src/test/scala/endless/example/logic/BookingEntitySuite.scala
@@ -4,9 +4,8 @@ import cats.effect.IO
 import endless.core.interpret.EntityT
 import endless.core.interpret.EntityT._
 import endless.example.algebra.BookingAlg.{BookingAlreadyExists, BookingUnknown, BookingWasRejected}
-import endless.example.data.Booking.LatLon
 import endless.example.data.BookingEvent._
-import endless.example.data.{Booking, BookingEvent}
+import endless.example.data.{Booking, BookingEvent, LatLon}
 import org.scalacheck.effect.PropF._
 import org.typelevel.log4cats.testing.TestingLogger
 

--- a/example/src/test/scala/endless/example/logic/BookingEventApplierSuite.scala
+++ b/example/src/test/scala/endless/example/logic/BookingEventApplierSuite.scala
@@ -1,8 +1,7 @@
 package endless.example.logic
 
-import endless.example.data.Booking
-import endless.example.data.Booking.LatLon
 import endless.example.data.BookingEvent._
+import endless.example.data.{Booking, LatLon}
 import org.scalacheck.Prop._
 
 //#example

--- a/example/src/test/scala/endless/example/logic/Generators.scala
+++ b/example/src/test/scala/endless/example/logic/Generators.scala
@@ -1,13 +1,8 @@
 package endless.example.logic
 
-import endless.example.algebra.BookingAlg.{
-  BookingAlreadyExists,
-  BookingUnknown,
-  BookingWasRejected,
-  CancelError
-}
-import endless.example.data.Booking
-import endless.example.data.Booking.{BookingID, LatLon}
+import endless.example.algebra.BookingAlg.{BookingAlreadyExists, BookingUnknown, BookingWasRejected, CancelError}
+import endless.example.data.Booking.BookingID
+import endless.example.data.{Booking, LatLon, Speed}
 import org.scalacheck.{Arbitrary, Gen}
 
 import java.time.Instant
@@ -17,6 +12,7 @@ trait Generators {
     latitude <- Gen.double
     longitude <- Gen.double
   } yield LatLon(latitude, longitude)
+  implicit val speedGen: Gen[Speed] = Gen.double.map(Speed(_))
   implicit val instantGen: Gen[Instant] = Gen.long.map(Instant.ofEpochMilli)
   implicit val bookingIDGen: Gen[BookingID] = Gen.uuid.map(BookingID(_))
   implicit val bookingGen: Gen[Booking] = for {
@@ -34,6 +30,7 @@ trait Generators {
 
   implicit val arbBooking: Arbitrary[Booking] = Arbitrary(bookingGen)
   implicit val arbLatLon: Arbitrary[LatLon] = Arbitrary(latLonGen)
+  implicit val arbSpeed: Arbitrary[Speed] = Arbitrary(speedGen)
   implicit val arbBookingAlreadyExists: Arbitrary[BookingAlreadyExists] = Arbitrary(
     bookingAlreadyExists
   )

--- a/example/src/test/scala/endless/example/logic/VehicleEntitySuite.scala
+++ b/example/src/test/scala/endless/example/logic/VehicleEntitySuite.scala
@@ -1,0 +1,76 @@
+package endless.example.logic
+
+import cats.effect.IO
+import endless.core.interpret.DurableEntityT
+import endless.core.interpret.DurableEntityT._
+import endless.example.data.{LatLon, Speed, Vehicle}
+import org.scalacheck.effect.PropF._
+import org.typelevel.log4cats.testing.TestingLogger
+
+class VehicleEntitySuite
+    extends munit.CatsEffectSuite
+    with munit.ScalaCheckEffectSuite
+    with Generators {
+  implicit private val logger: TestingLogger[IO] = TestingLogger.impl[IO]()
+  private val vehicleAlg = VehicleEntity(DurableEntityT.instance[IO, Vehicle])
+
+  test("set position") {
+    forAllF { latLon: LatLon =>
+      vehicleAlg
+        .setPosition(latLon)
+        .run(State.None)
+        .map {
+          case (State.Updated(vehicle), ()) =>
+            assertEquals(vehicle.position, Some(latLon))
+          case _ => fail("incorrect vehicle state")
+        }
+        .flatMap(_ => assertIOBoolean(logger.logged.map(_.nonEmpty)))
+    }
+  }
+
+  test("set speed") {
+    forAllF { speed: Speed =>
+      vehicleAlg
+        .setSpeed(speed)
+        .run(State.None)
+        .map {
+          case (State.Updated(vehicle), ()) =>
+            assertEquals(vehicle.speed, Some(speed))
+          case _ => fail("incorrect vehicle state")
+        }
+        .flatMap(_ => assertIOBoolean(logger.logged.map(_.nonEmpty)))
+    }
+  }
+
+  test("get speed") {
+    forAllF { (speed: Option[Speed], latLon: Option[LatLon]) =>
+      vehicleAlg.getSpeed
+        .runA(State.Existing(Vehicle(latLon, speed)))
+        .map(result => assertEquals(result, speed))
+    }
+  }
+
+  test("get speed when unknown") {
+    assertIOBoolean(
+      vehicleAlg.getSpeed
+        .runA(State.None)
+        .map(_.isEmpty)
+    )
+  }
+
+  test("get position") {
+    forAllF { (speed: Option[Speed], latLon: Option[LatLon]) =>
+      vehicleAlg.getPosition
+        .runA(State.Existing(Vehicle(latLon, speed)))
+        .map(result => assertEquals(result, latLon))
+    }
+  }
+
+  test("get position when unknown") {
+    assertIOBoolean(
+      vehicleAlg.getPosition
+        .runA(State.None)
+        .map(_.isEmpty)
+    )
+  }
+}

--- a/example/src/test/scala/endless/example/protocol/BookingCommandProtocolSuite.scala
+++ b/example/src/test/scala/endless/example/protocol/BookingCommandProtocolSuite.scala
@@ -5,7 +5,7 @@ import cats.syntax.functor._
 import endless.\/
 import endless.example.algebra.BookingAlg
 import endless.example.algebra.BookingAlg.CancelError
-import endless.example.data.Booking
+import endless.example.data.{Booking, LatLon}
 import endless.example.logic.Generators
 import org.scalacheck.Prop.forAll
 
@@ -31,8 +31,8 @@ class BookingCommandProtocolSuite extends munit.ScalaCheckSuite with Generators 
               bookingID: Booking.BookingID,
               time: Instant,
               passengerCount: Int,
-              origin: Booking.LatLon,
-              destination: Booking.LatLon
+              origin: LatLon,
+              destination: LatLon
           ): Id[BookingAlg.BookingAlreadyExists \/ Unit] = reply
         })
         .map(incomingCommand.replyEncoder.encode(_))
@@ -55,13 +55,13 @@ class BookingCommandProtocolSuite extends munit.ScalaCheckSuite with Generators 
   }
 
   test("change origin") {
-    forAll { (newOrigin: Booking.LatLon, reply: BookingAlg.BookingUnknown.type \/ Unit) =>
+    forAll { (newOrigin: LatLon, reply: BookingAlg.BookingUnknown.type \/ Unit) =>
       val outgoingCommand = protocol.client.changeOrigin(newOrigin)
       val incomingCommand = protocol.server[Id].decode(outgoingCommand.payload)
       val encodedReply = incomingCommand
         .runWith(new TestBookingAlg {
           override def changeOrigin(
-              origin: Booking.LatLon
+              origin: LatLon
           ): Id[BookingAlg.BookingUnknown.type \/ Unit] = reply
         })
         .map(incomingCommand.replyEncoder.encode(_))
@@ -70,13 +70,13 @@ class BookingCommandProtocolSuite extends munit.ScalaCheckSuite with Generators 
   }
 
   test("change destination") {
-    forAll { (newDestination: Booking.LatLon, reply: BookingAlg.BookingUnknown.type \/ Unit) =>
+    forAll { (newDestination: LatLon, reply: BookingAlg.BookingUnknown.type \/ Unit) =>
       val outgoingCommand = protocol.client.changeDestination(newDestination)
       val incomingCommand = protocol.server[Id].decode(outgoingCommand.payload)
       val encodedReply = incomingCommand
         .runWith(new TestBookingAlg {
           override def changeDestination(
-              destination: Booking.LatLon
+              destination: LatLon
           ): Id[BookingAlg.BookingUnknown.type \/ Unit] = reply
         })
         .map(incomingCommand.replyEncoder.encode(_))
@@ -87,8 +87,8 @@ class BookingCommandProtocolSuite extends munit.ScalaCheckSuite with Generators 
   test("change origin and destination") {
     forAll {
       (
-          newOrigin: Booking.LatLon,
-          newDestination: Booking.LatLon,
+          newOrigin: LatLon,
+          newDestination: LatLon,
           reply: BookingAlg.BookingUnknown.type \/ Unit
       ) =>
         val outgoingCommand = protocol.client.changeOriginAndDestination(newOrigin, newDestination)
@@ -96,8 +96,8 @@ class BookingCommandProtocolSuite extends munit.ScalaCheckSuite with Generators 
         val encodedReply = incomingCommand
           .runWith(new TestBookingAlg {
             override def changeOriginAndDestination(
-                origin: Booking.LatLon,
-                destination: Booking.LatLon
+                origin: LatLon,
+                destination: LatLon
             ): Id[BookingAlg.BookingUnknown.type \/ Unit] = reply
           })
           .map(incomingCommand.replyEncoder.encode(_))
@@ -123,24 +123,24 @@ class BookingCommandProtocolSuite extends munit.ScalaCheckSuite with Generators 
         bookingID: Booking.BookingID,
         time: Instant,
         passengerCount: Int,
-        origin: Booking.LatLon,
-        destination: Booking.LatLon
+        origin: LatLon,
+        destination: LatLon
     ): Id[BookingAlg.BookingAlreadyExists \/ Unit] = throw new RuntimeException(
       "not supposed to be called"
     )
     def get: Id[BookingAlg.BookingUnknown.type \/ Booking] = throw new RuntimeException(
       "not supposed to be called"
     )
-    def changeOrigin(newOrigin: Booking.LatLon): Id[BookingAlg.BookingUnknown.type \/ Unit] =
+    def changeOrigin(newOrigin: LatLon): Id[BookingAlg.BookingUnknown.type \/ Unit] =
       throw new RuntimeException("not supposed to be called")
     def changeDestination(
-        newDestination: Booking.LatLon
+        newDestination: LatLon
     ): Id[BookingAlg.BookingUnknown.type \/ Unit] = throw new RuntimeException(
       "not supposed to be called"
     )
     def changeOriginAndDestination(
-        newOrigin: Booking.LatLon,
-        newDestination: Booking.LatLon
+        newOrigin: LatLon,
+        newDestination: LatLon
     ): Id[BookingAlg.BookingUnknown.type \/ Unit] = throw new RuntimeException(
       "not supposed to be called"
     )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,8 +5,9 @@ object Dependencies {
   lazy val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed"
   lazy val akkaPersistenceTyped = "com.typesafe.akka" %% "akka-persistence-typed"
   lazy val akkaClusterTyped = "com.typesafe.akka" %% "akka-cluster-typed"
-  lazy val akkaClusterShardingTyped =
-    "com.typesafe.akka" %% "akka-cluster-sharding-typed"
+  lazy val akkaClusterShardingTyped = "com.typesafe.akka" %% "akka-cluster-sharding-typed"
+
+  lazy val akkaTypedTestkit = "com.typesafe.akka" %% "akka-actor-testkit-typed"
   lazy val akkaPersistenceTestkit = "com.typesafe.akka" %% "akka-persistence-testkit"
 
   lazy val akka =

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -89,4 +89,8 @@ object Dependencies {
   lazy val kittens = Seq("org.typelevel" %% "kittens" % kittensVersion)
 
   lazy val scodecCore = Seq("org.scodec" %% "scodec-core" % "1.11.10")
+
+  lazy val scalapbCustomizations = Seq(
+    "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf"
+  )
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,7 @@
 import sbt._
 
 object Dependencies {
-  lazy val akkaVersion = "2.6.5"
+  lazy val akkaVersion = "2.6.17"
   lazy val akkaActorTyped = "com.typesafe.akka" %% "akka-actor-typed"
   lazy val akkaPersistenceTyped = "com.typesafe.akka" %% "akka-persistence-typed"
   lazy val akkaClusterTyped = "com.typesafe.akka" %% "akka-cluster-typed"

--- a/protobuf/src/main/scala/endless/protobuf/ScalaPbSerializer.scala
+++ b/protobuf/src/main/scala/endless/protobuf/ScalaPbSerializer.scala
@@ -1,0 +1,68 @@
+package endless.protobuf
+
+import akka.actor.ExtendedActorSystem
+import akka.serialization.BaseSerializer
+import scalapb.GeneratedMessageCompanion
+
+import java.util.concurrent.atomic.AtomicReference
+
+/*
+ Akka serializer making use of scalapb-generated classes for protobuf serialization
+ Inspired by https://gist.github.com/thesamet/5d0349b40d3dc92859a1a2eafba448d5
+ */
+@SuppressWarnings(
+  Array(
+    "org.wartremover.warts.AsInstanceOf",
+    "org.wartremover.warts.Equals",
+    "org.wartremover.warts.Null"
+  )
+)
+class ScalaPbSerializer(val system: ExtendedActorSystem) extends BaseSerializer {
+  private val classToCompanionMapRef =
+    new AtomicReference[Map[Class[_], GeneratedMessageCompanion[_]]](Map.empty)
+
+  override def toBinary(o: AnyRef): Array[Byte] = o match {
+    case e: scalapb.GeneratedMessage => e.toByteArray
+    case _ => throw new IllegalArgumentException("Need a subclass of scalapb.GeneratedMessage")
+  }
+
+  override def includeManifest: Boolean = true
+
+  override def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef =
+    manifest match {
+      case Some(clazz) =>
+        // noinspection ScalaStyle
+        @scala.annotation.tailrec
+        def messageCompanion(
+            companion: GeneratedMessageCompanion[_] = null
+        ): GeneratedMessageCompanion[_] = {
+          val classToCompanion = classToCompanionMapRef.get()
+          classToCompanion.get(clazz) match {
+            case Some(cachedCompanion) => cachedCompanion
+            case None =>
+              val uncachedCompanion =
+                if (companion eq null)
+                  Class
+                    .forName(clazz.getName + "$", true, clazz.getClassLoader)
+                    .getField("MODULE$")
+                    .get(())
+                    .asInstanceOf[GeneratedMessageCompanion[_]]
+                else companion
+              if (
+                classToCompanionMapRef.compareAndSet(
+                  classToCompanion,
+                  classToCompanion.updated(clazz, uncachedCompanion)
+                )
+              )
+                uncachedCompanion
+              else
+                messageCompanion(uncachedCompanion)
+          }
+        }
+        messageCompanion().parseFrom(bytes).asInstanceOf[AnyRef]
+      case _ =>
+        throw new IllegalArgumentException(
+          "Need a ScalaPB companion class to be able to deserialize."
+        )
+    }
+}

--- a/protobuf/src/test/scala/endless/protobuf/ScalaPbSerializerSuite.scala
+++ b/protobuf/src/test/scala/endless/protobuf/ScalaPbSerializerSuite.scala
@@ -1,0 +1,59 @@
+package endless.protobuf
+
+import akka.actor.ActorSystem
+import akka.serialization.{Serialization, SerializationExtension}
+import akka.testkit.TestKit
+import com.typesafe.config.ConfigFactory
+import endless.protobuf.test.proto.dummy.DummyCommand
+
+class ScalaPbSerializerSuite extends munit.FunSuite {
+  val akkaSerialization = new Fixture[Serialization]("system") {
+    def apply(): Serialization = {
+      SerializationExtension(
+        new TestKit(
+          ActorSystem(
+            "ScalaPbSerializerSpec",
+            ConfigFactory.parseString(ScalaPbSerializerSuite.serializationConfig)
+          )
+        ).system
+      )
+    }
+  }
+
+  test("be found by akka serialization extension when asked for it for test type") {
+    val clasz = akkaSerialization().serializerFor(classOf[DummyCommand]).getClass
+    assert(clasz == classOf[ScalaPbSerializer])
+  }
+
+  test("serialize and deserialize event correctly") {
+    val dummy = DummyCommand("dummy")
+    val serialized = akkaSerialization().serialize(dummy)
+    assert(serialized.isSuccess)
+    val deserialized =
+      akkaSerialization().deserialize(serialized.get, classOf[DummyCommand])
+    assert(deserialized.isSuccess)
+    assertEquals(deserialized.get, dummy)
+  }
+
+}
+
+object ScalaPbSerializerSuite {
+  val serializationConfig: String =
+    """
+      |akka {
+      |  actor {
+      |    serializers {
+      |      scalapb = "endless.protobuf.ScalaPbSerializer"
+      |    }
+      |
+      |    serialization-bindings {
+      |      "scalapb.GeneratedMessage" = scalapb
+      |    }
+      |
+      |    serialization-identifiers {
+      |      "endless.protobuf.ScalaPbSerializer" = 4242
+      |    }
+      |  }
+      |}
+    """.stripMargin
+}

--- a/runtime/src/main/scala/endless/runtime/akka/DurableDeployer.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/DurableDeployer.scala
@@ -4,8 +4,9 @@ import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.{ActorRef, ActorSystem, Behavior}
 import akka.cluster.sharding.typed.ShardingEnvelope
 import akka.cluster.sharding.typed.scaladsl.{ClusterSharding, EntityContext, EntityTypeKey}
-import akka.persistence.typed.scaladsl.{Effect, EventSourcedBehavior}
-import akka.persistence.typed.{PersistenceId, RecoveryCompleted, RecoveryFailed}
+import akka.persistence.typed.PersistenceId
+import akka.persistence.typed.state.scaladsl.{DurableStateBehavior, Effect}
+import akka.persistence.typed.state.{RecoveryCompleted, RecoveryFailed}
 import akka.util.Timeout
 import cats.effect.kernel.{Async, Resource}
 import cats.effect.std.Dispatcher
@@ -15,22 +16,22 @@ import cats.syntax.functor._
 import cats.syntax.show._
 import cats.tagless.FunctorK
 import endless.core.entity._
-import endless.core.event.EventApplier
+import endless.core.interpret.DurableEntityT.{DurableEntityT, State}
 import endless.core.interpret.EffectorT._
 import endless.core.interpret._
 import endless.core.protocol.{CommandProtocol, CommandRouter, EntityIDCodec}
 import endless.runtime.akka.data._
 import org.typelevel.log4cats.Logger
 
-trait Deployer {
+trait DurableDeployer {
 
   /** This function brings everything together and delivers a `Resource` with the repository
     * instance in context `F` bundled with the ref to the shard region actor returned by the call to
     * `ClusterSharding`.
     *
     * The function is parameterized with the context `F` and the various involved types: `S` for
-    * entity state, `E` for events, `ID` for entity ID and `Alg` & `RepositoryAlg` for entity and
-    * repository algebras respectively (both higher-kinded type constructors).
+    * entity state, `ID` for entity ID and `Alg` & `RepositoryAlg` for entity and repository
+    * algebras respectively (both higher-kinded type constructors).
     *
     * In order to bridge Akka's implicit asynchronicity with the side-effect free context `F` used
     * for algebras, it requires `Async` from `F`. This makes it possible to use the `Dispatcher`
@@ -48,21 +49,22 @@ trait Deployer {
     * configure aspects such as recovery, etc.
     *
     * All remaining typeclass instances for entity operation are pulled from implicit scope: entity
-    * name provider, entity ID encoder, command protocol, event application function in addition to
-    * the usual akka ask timeout, actor system and cluster sharding extension.
+    * name provider, entity ID encoder, command protocol function in addition to the usual akka ask
+    * timeout, actor system and cluster sharding extension.
     *
     * Although its signature looks complicated, in practice usage of this method isn't difficult
     * with the proper implicits and definitions: refer to the sample application for example usage:
     *
-    * \```scala deployEntity[IO, Booking, BookingEvent, BookingID, BookingAlg,
-    * BookingRepositoryAlg]( BookingEntity(_), BookingRepository(_), BookingEffector(_) )```
+    * \```scala deployDurableEntity[IO, Vehicle, VehicleID, VehicleAlg,
+    * VehicleRepositoryAlg](VehicleEntity(_), VehicleRepository(_), VehicleEffector(_) )```
     *
-    * '''Important''': `deployEntity` needs to be called upon application startup, before joining
-    * the cluster as the `ClusterSharding` extension needs to know about the various entity types
-    * beforehand.
+    * '''Important''': `deployDurableEntity` needs to be called upon application startup, before
+    * joining the cluster as the `ClusterSharding` extension needs to know about the various entity
+    * types beforehand.
     *
     * @param createEntity
-    *   creator for entity algebra accepting an instance of `Entity`, interpreted with `EntityT`
+    *   creator for entity algebra accepting an instance of `DurableEntity`, interpreted with
+    *   `DurableEntityT`
     * @param createRepository
     *   creator for repository algebra accepting an instance of `Repository`
     * @param createEffector
@@ -70,9 +72,9 @@ trait Deployer {
     *   effector processes require access to the repository itself), interpreted with `EffectorT`
     *   (you can pass in `(_,_) => EffectorT.unit` for unit effector)
     * @param customizeBehavior
-    *   hook to further customize Akka `EventSourcedBehavior`. By default the behavior enforces
-    *   replies, and is configured with command handler and event handler. It also triggers the
-    *   effector upon successful recovery as well as logs in warning upon recovery failure.
+    *   hook to further customize Akka `DurableStateBehavior`. By default the behavior enforces
+    *   replies, and is configured with the command handler. It also triggers the effector upon
+    *   successful recovery as well as logs in warning upon recovery failure.
     * @param sharding
     *   Akka cluster sharding extension
     * @param actorSystem
@@ -81,16 +83,12 @@ trait Deployer {
     *   entity name provider
     * @param commandProtocol
     *   instance of command protocol for the algebra (serialization specification)
-    * @param eventApplier
-    *   instance of event application function (event folding on state)
     * @param askTimeout
     *   Akka ask timeout
     * @tparam F
     *   context, requires instances of `Async` and `Logger`
     * @tparam S
     *   state
-    * @tparam E
-    *   event
     * @tparam ID
     *   entity ID, requires an instance of `EntityIDCodec`
     * @tparam Alg
@@ -101,10 +99,12 @@ trait Deployer {
     *   resource (with underlying allocated dispatcher) containing the algebra in `F` context to
     *   interact with the entity together with Akka shard region actor ref
     */
-  def deployEntity[F[_]: Async: Logger, S, E, ID: EntityIDCodec, Alg[_[_]]: FunctorK, RepositoryAlg[
+  def deployDurableEntity[F[_]: Async: Logger, S, ID: EntityIDCodec, Alg[
+      _[_]
+  ]: FunctorK, RepositoryAlg[
       _[_]
   ]](
-      createEntity: Entity[EntityT[F, S, E, *], S, E] => Alg[EntityT[F, S, E, *]],
+      createEntity: DurableEntity[DurableEntityT[F, S, *], S] => Alg[DurableEntityT[F, S, *]],
       createRepository: Repository[F, ID, Alg] => RepositoryAlg[F],
       createEffector: (
           Effector[EffectorT[F, S, Alg, *], S, Alg],
@@ -112,10 +112,9 @@ trait Deployer {
       ) => EffectorT[F, S, Alg, Unit],
       customizeBehavior: (
           EntityContext[Command],
-          EventSourcedBehavior[Command, E, Option[S]]
+          DurableStateBehavior[Command, Option[S]]
       ) => Behavior[Command] =
-        (_: EntityContext[Command], behavior: EventSourcedBehavior[Command, E, Option[S]]) =>
-          behavior,
+        (_: EntityContext[Command], behavior: DurableStateBehavior[Command, Option[S]]) => behavior,
       customizeEntity: akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[
         Command
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]] =
@@ -125,7 +124,6 @@ trait Deployer {
       actorSystem: ActorSystem[_],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
-      eventApplier: EventApplier[S, E],
       askTimeout: Timeout
   ): Resource[F, (RepositoryAlg[F], ActorRef[ShardingEnvelope[Command]])] =
     new DeployEntity(
@@ -138,10 +136,10 @@ trait Deployer {
 
   final class EventApplierException(error: String) extends RuntimeException(error)
 
-  private class DeployEntity[F[_]: Async: Logger, S, E, ID: EntityIDCodec, Alg[
+  private class DeployEntity[F[_]: Async: Logger, S, ID: EntityIDCodec, Alg[
       _[_]
   ]: FunctorK, RepositoryAlg[_[_]]](
-      createEntity: Entity[EntityT[F, S, E, *], S, E] => Alg[EntityT[F, S, E, *]],
+      createEntity: DurableEntity[DurableEntityT[F, S, *], S] => Alg[DurableEntityT[F, S, *]],
       createRepository: Repository[F, ID, Alg] => RepositoryAlg[F],
       createEffector: (
           Effector[EffectorT[F, S, Alg, *], S, Alg],
@@ -149,7 +147,7 @@ trait Deployer {
       ) => EffectorT[F, S, Alg, Unit],
       customizeBehavior: (
           EntityContext[Command],
-          EventSourcedBehavior[Command, E, Option[S]]
+          DurableStateBehavior[Command, Option[S]]
       ) => Behavior[Command],
       customizeEntity: akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[
         Command
@@ -159,11 +157,10 @@ trait Deployer {
       actorSystem: ActorSystem[_],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
-      eventApplier: EventApplier[S, E],
       askTimeout: Timeout
   ) {
-    private implicit val interpretedEntityAlg: Alg[EntityT[F, S, E, *]] = createEntity(
-      EntityT.instance
+    private implicit val interpretedEntityAlg: Alg[DurableEntityT[F, S, *]] = createEntity(
+      DurableEntityT.instance
     )
     private implicit val commandRouter: CommandRouter[F, ID] = ShardingCommandRouter.apply
     private val interpretedRepository: Repository[F, ID, Alg] = RepositoryT.apply[F, ID, Alg]
@@ -183,12 +180,11 @@ trait Deployer {
             implicit val passivator: EntityPassivator = new EntityPassivator(context, actor)
             customizeBehavior(
               context,
-              EventSourcedBehavior
-                .withEnforcedReplies[Command, E, Option[S]](
+              DurableStateBehavior
+                .withEnforcedReplies[Command, Option[S]](
                   PersistenceId(entityTypeKey.name, context.entityId),
                   Option.empty[S],
-                  commandHandler = handleCommand,
-                  eventHandler = handleEvent
+                  commandHandler = handleCommand
                 )
                 .receiveSignal {
                   case (state, RecoveryCompleted) =>
@@ -216,54 +212,42 @@ trait Deployer {
         (repository, sharding.init(customizeEntity(akkaEntity)))
       }
 
-    private def handleEvent(state: Option[S], event: E)(implicit
-        dispatcher: Dispatcher[F]
-    ) = eventApplier.apply(state, event) match {
-      case Left(error) =>
-        dispatcher.unsafeRunSync(Logger[F].warn(error))
-        throw new EventApplierException(error)
-      case Right(newState) => newState
-    }
-
     private def handleCommand(state: Option[S], command: Command)(implicit
         dispatcher: Dispatcher[F],
         passivator: EntityPassivator
     ) = {
       val incomingCommand =
-        commandProtocol.server[EntityT[F, S, E, *]].decode(command.payload)
+        commandProtocol.server[DurableEntityT[F, S, *]].decode(command.payload)
       val effect = Logger[F].debug(
         show"Handling command for ${nameProvider()} entity ${command.id}"
       ) >> incomingCommand
         .runWith(interpretedEntityAlg)
-        .run(state)
-        .flatMap {
-          case Left(error) =>
-            Logger[F].warn(error) >> Effect.unhandled[E, Option[S]].thenNoReply().pure[F]
-          case Right((events, reply)) if events.nonEmpty =>
-            Effect
-              .persist(events.toList)
-              .thenRun((state: Option[S]) =>
-                // run the effector asynchronously, as it can describe long-running processes
-                dispatcher.unsafeRunAndForget(
-                  interpretedEffector
-                    .runS(
-                      state,
-                      interpretedRepository
-                        .entityFor(implicitly[EntityIDCodec[ID]].decode(command.id))
-                    )
-                    .map(passivator.apply)
-                )
+        .run(state match {
+          case Some(value) => DurableEntityT.State.Existing(value)
+          case None        => DurableEntityT.State.None
+        })
+        .flatMap { case (state, reply) =>
+          (state match {
+            case State.None           => Effect.none
+            case State.Existing(_)    => Effect.none
+            case State.Updated(state) => Effect.persist(Option(state))
+          })
+            .thenRun((state: Option[S]) =>
+              // run the effector asynchronously, as it can describe long-running processes
+              dispatcher.unsafeRunAndForget(
+                interpretedEffector
+                  .runS(
+                    state,
+                    interpretedRepository
+                      .entityFor(implicitly[EntityIDCodec[ID]].decode(command.id))
+                  )
+                  .map(passivator.apply)
               )
-              .thenReply(command.replyTo) { _: Option[S] =>
-                Reply(incomingCommand.replyEncoder.encode(reply))
-              }
-              .pure[F]
-          case Right((_, reply)) =>
-            Effect
-              .reply[Reply, E, Option[S]](command.replyTo)(
-                Reply(incomingCommand.replyEncoder.encode(reply))
-              )
-              .pure[F]
+            )
+            .thenReply(command.replyTo) { _: Option[S] =>
+              Reply(incomingCommand.replyEncoder.encode(reply))
+            }
+            .pure[F]
         }
       dispatcher.unsafeRunSync(effect)
     }

--- a/runtime/src/main/scala/endless/runtime/akka/syntax/package.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/syntax/package.scala
@@ -3,5 +3,5 @@ package endless.runtime.akka
 import endless.core.interpret.LoggerLiftingHelper
 
 package object syntax {
-  object deploy extends Deployer with LoggerLiftingHelper
+  object deploy extends Deployer with DurableDeployer with LoggerLiftingHelper
 }


### PR DESCRIPTION
Add a new `DurableEntity` typeclass which represents reader-writer capabilities for `F` with direct state persistence semantics, i.e., the ability to store the full state after processing each command instead of a sequence of events.

For some use cases, e.g. in scenarios with high-frequency updates where each individual update doesn't carry valuable meaning to the domain, events aren't relevant and flashing the full state is preferable.

Such "durable" entities still benefit from sharding, passivation, rebalancing, automatic recovery, etc. while keeping the persistence model simple. In effect, this is a way to implement CRUD-like distributed entities while retaining the advantages of actors, such as the ability to actively schedule side-effects, precise state-machine semantics, consistent distributed in-memory state, etc.   

This is (obviously) backed by the `DurableStateBehavior` introduced in Akka 2.6.17
