### PR TITLE
Introduce unchanged passivation behavior in effector

### DIFF
--- a/core/src/main/scala/endless/core/interpret/EffectorT.scala
+++ b/core/src/main/scala/endless/core/interpret/EffectorT.scala
@@ -56,9 +56,9 @@ object EffectorT extends LoggerLiftingHelper {
       val effectorT: EffectorT[F, S, Alg, A]
   ) {
     def runA(entityState: Option[S], entity: Alg[F]): F[A] =
-      effectorT.runA(Env(entityState, entity), PassivationState.Disabled)
+      effectorT.runA(Env(entityState, entity), PassivationState.Unchanged)
     def runS(entityState: Option[S], entity: Alg[F]): F[PassivationState] =
-      effectorT.runS(Env(entityState, entity), PassivationState.Disabled)
+      effectorT.runS(Env(entityState, entity), PassivationState.Unchanged)
     def run(
         entityState: Option[S],
         entity: Alg[F],
@@ -73,6 +73,7 @@ object EffectorT extends LoggerLiftingHelper {
   object PassivationState {
     final case class After(duration: FiniteDuration) extends PassivationState
     object Disabled extends PassivationState
+    object Unchanged extends PassivationState
   }
 
   implicit def instance[F[_]: Applicative, S, Alg[_[_]]: FunctorK]

--- a/core/src/test/scala/endless/core/interpret/EffectorTSuite.scala
+++ b/core/src/test/scala/endless/core/interpret/EffectorTSuite.scala
@@ -56,11 +56,16 @@ class EffectorTSuite extends DisciplineSuite with TestInstances {
     implicit val passivationStateOrder: Order[PassivationState] =
       (x: PassivationState, y: PassivationState) =>
         (x, y) match {
-          case (PassivationState.Disabled, PassivationState.Disabled) => 0
+          case (PassivationState.Disabled, PassivationState.Disabled)  => 0
+          case (PassivationState.Disabled, PassivationState.After(_))  => -1
+          case (PassivationState.Disabled, PassivationState.Unchanged) => -1
           case (PassivationState.After(before), PassivationState.After(after)) =>
             Order[FiniteDuration].compare(before, after)
-          case (PassivationState.After(_), PassivationState.Disabled) => 1
-          case (PassivationState.Disabled, PassivationState.After(_)) => -1
+          case (PassivationState.After(_), PassivationState.Disabled)   => 1
+          case (PassivationState.After(_), PassivationState.Unchanged)  => -1
+          case (PassivationState.Unchanged, PassivationState.Unchanged) => 0
+          case (PassivationState.Unchanged, PassivationState.Disabled)  => 1
+          case (PassivationState.Unchanged, PassivationState.After(_))  => 1
         }
 
     Order.by { ioaO =>

--- a/example/src/test/scala/endless/example/logic/BookingEffectorSuite.scala
+++ b/example/src/test/scala/endless/example/logic/BookingEffectorSuite.scala
@@ -68,7 +68,7 @@ class BookingEffectorSuite
             }
           }
         ),
-        PassivationState.Disabled
+        PassivationState.Unchanged
       )
     }
   }


### PR DESCRIPTION
Not specifying passivation currently disables it, which is surprising and can be an issue in scenarios with racing side-effects. This PR changes the behavior so that not specifying anything retains the scheduled passivation, if any. It also protects the passivation state from racing fibers.