### PR TITLE
Allow for transient entity-specific state via the effector mechanism

### DIFF
--- a/example/src/main/protobuf/vehicle/commands.proto
+++ b/example/src/main/protobuf/vehicle/commands.proto
@@ -11,6 +11,8 @@ message VehicleCommand {
     SetPositionV1Full set_position_v1 = 2;
     GetSpeedV1Full get_speed_v1 = 3;
     GetPositionV1Full get_position_v1 = 4;
+    GetRecoveryCountV1Full get_recovery_count_v1 = 5;
+    IncrementRecoveryCountV1Full increment_recovery_count_v1 = 6;
   }
 }
 
@@ -22,3 +24,5 @@ message SetPositionV1Full {
 }
 message GetSpeedV1Full {}
 message GetPositionV1Full {}
+message GetRecoveryCountV1Full {}
+message IncrementRecoveryCountV1Full {}

--- a/example/src/main/protobuf/vehicle/replies.proto
+++ b/example/src/main/protobuf/vehicle/replies.proto
@@ -13,3 +13,7 @@ message GetSpeedV1FullReply {
 message GetPositionV1FullReply {
   LatLonV1Full position = 1;
 }
+
+message GetRecoveryCountV1FullReply {
+  int32 recovery_count = 1;
+}

--- a/example/src/main/protobuf/vehicle/state.proto
+++ b/example/src/main/protobuf/vehicle/state.proto
@@ -7,4 +7,5 @@ import "vehicle/models.proto";
 message VehicleStateV1Full {
   LatLonV1Full position = 1;
   SpeedV1Full speed = 2;
+  uint32 recovery_count = 3;
 }

--- a/example/src/main/scala/endless/example/adapter/VehicleStateAdapter.scala
+++ b/example/src/main/scala/endless/example/adapter/VehicleStateAdapter.scala
@@ -8,15 +8,17 @@ import endless.example.proto.vehicle.state.VehicleStateV1Full
 class VehicleStateAdapter extends SnapshotAdapter[Option[Vehicle]] {
   def toJournal(state: Option[Vehicle]): Any = VehicleStateV1Full(
     state.flatMap(_.position.map(latLon => LatLonV1Full(latLon.lat, latLon.lon))),
-    state.flatMap(_.speed.map(s => SpeedV1Full(s.metersPerSecond)))
+    state.flatMap(_.speed.map(s => SpeedV1Full(s.metersPerSecond))),
+    state.map(_.recoveryCount).getOrElse(0)
   )
 
   def fromJournal(from: Any): Option[Vehicle] = from match {
-    case VehicleStateV1Full(position, speed, _) =>
+    case VehicleStateV1Full(position, speed, recoveryCount, _) =>
       Some(
         Vehicle(
           position.map(latLon => LatLon(latLon.lat, latLon.lon)),
-          speed.map(_.metersPerSecond).map(Speed(_))
+          speed.map(_.metersPerSecond).map(Speed(_)),
+          recoveryCount
         )
       )
   }

--- a/example/src/main/scala/endless/example/algebra/VehicleAlg.scala
+++ b/example/src/main/scala/endless/example/algebra/VehicleAlg.scala
@@ -9,6 +9,8 @@ trait VehicleAlg[F[_]] {
   def setPosition(position: LatLon): F[Unit]
   def getSpeed: F[Option[Speed]]
   def getPosition: F[Option[LatLon]]
+  def getRecoveryCount: F[Int]
+  def incrementRecoveryCount: F[Unit]
 }
 //#definition
 

--- a/example/src/main/scala/endless/example/data/Vehicle.scala
+++ b/example/src/main/scala/endless/example/data/Vehicle.scala
@@ -4,7 +4,7 @@ import cats.Show
 
 import java.util.UUID
 
-final case class Vehicle(position: Option[LatLon], speed: Option[Speed])
+final case class Vehicle(position: Option[LatLon], speed: Option[Speed], recoveryCount: Int = 0)
 
 object Vehicle {
   final case class VehicleID(id: UUID) extends AnyVal

--- a/example/src/main/scala/endless/example/logic/VehicleEffector.scala
+++ b/example/src/main/scala/endless/example/logic/VehicleEffector.scala
@@ -1,0 +1,41 @@
+package endless.example.logic
+
+import cats.effect.Ref
+import cats.effect.kernel.Sync
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.{Applicative, Monad}
+import endless.core.entity.Effector
+import endless.core.interpret.EffectorT
+import endless.core.interpret.EffectorT.EffectorT
+import endless.example.algebra.VehicleAlg
+import endless.example.data.Vehicle
+import endless.example.logic.VehicleEffector.Interpreted
+
+import scala.concurrent.duration._
+
+class VehicleEffector[F[_]: Monad](
+    effector: Effector[Interpreted[F, *], Vehicle, VehicleAlg],
+    justRecoveredRef: Ref[F, Boolean]
+) {
+  private lazy val aggressivePassivation = effector.enablePassivation(1.second)
+
+  def apply: Interpreted[F, Unit] = {
+    for {
+      justRecovered <- EffectorT.liftF(justRecoveredRef.getAndUpdate(_ => false))
+      _ <- Applicative[Interpreted[F, *]].whenA(justRecovered)(
+        effector.self.flatMap(_.incrementRecoveryCount)
+      )
+      _ <- aggressivePassivation
+    } yield ()
+  }
+}
+
+object VehicleEffector {
+  type Interpreted[F[_], A] = EffectorT[F, Vehicle, VehicleAlg, A]
+
+  def apply[F[_]: Sync](
+      effector: Effector[Interpreted[F, *], Vehicle, VehicleAlg]
+  ): F[VehicleEffector[F]] =
+    Ref[F].of(true).map(justRecovered => new VehicleEffector[F](effector, justRecovered))
+}

--- a/example/src/main/scala/endless/example/logic/VehicleEntity.scala
+++ b/example/src/main/scala/endless/example/logic/VehicleEntity.scala
@@ -35,4 +35,9 @@ final case class VehicleEntity[F[_]: Logger](entity: DurableEntity[F, Vehicle])
   def getSpeed: F[Option[Speed]] = read.map(_.flatMap(_.speed))
 
   def getPosition: F[Option[LatLon]] = read.map(_.flatMap(_.position))
+
+  def getRecoveryCount: F[Int] = read.map(_.map(_.recoveryCount).getOrElse(0))
+
+  def incrementRecoveryCount: F[Unit] =
+    modify(vehicle => vehicle.copy(recoveryCount = vehicle.recoveryCount + 1))
 }

--- a/example/src/test/scala/endless/example/logic/VehicleEntitySuite.scala
+++ b/example/src/test/scala/endless/example/logic/VehicleEntitySuite.scala
@@ -73,4 +73,32 @@ class VehicleEntitySuite
         .map(_.isEmpty)
     )
   }
+
+  test("get recovery count") {
+    forAllF { (speed: Option[Speed], latLon: Option[LatLon], recoveryCount: Int) =>
+      vehicleAlg.getRecoveryCount
+        .runA(State.Existing(Vehicle(latLon, speed, recoveryCount)))
+        .map(result => assertEquals(result, recoveryCount))
+    }
+  }
+
+  test("get recovery count when unknown") {
+    assertIOBoolean(
+      vehicleAlg.getRecoveryCount
+        .runA(State.None)
+        .map(_ == 0)
+    )
+  }
+
+  test("increment recovery count") {
+    forAllF { (speed: Option[Speed], latLon: Option[LatLon], recoveryCount: Int) =>
+      vehicleAlg.incrementRecoveryCount
+        .run(State.Existing(Vehicle(latLon, speed, recoveryCount)))
+        .map {
+          case (State.Updated(vehicle), ()) =>
+            assertEquals(vehicle.recoveryCount, recoveryCount + 1)
+          case _ => fail("incorrect vehicle state")
+        }
+    }
+  }
 }


### PR DESCRIPTION
Effector is instantiated in F context upon actor recovery by a synchronous call to the dispatcher. This makes it possible to maintain an in-memory stateful effector, e.g., to implement some caching