### PR TITLE
Support SBR-decided shutdowns

### DIFF
--- a/example/src/main/scala/endless/example/ExampleApp.scala
+++ b/example/src/main/scala/endless/example/ExampleApp.scala
@@ -82,7 +82,7 @@ object ExampleApp {
                 )
               )
               .map { case ((bookingRepository, _), (vehicleRepository, _)) =>
-                httpService(bookingRepository, vehicleRepository)
+                httpService(bookingRepository, vehicleRepository, cluster)
               }
               .flatMap(service =>
                 BlazeServerBuilder[IO]

--- a/example/src/main/scala/endless/example/ExampleApp.scala
+++ b/example/src/main/scala/endless/example/ExampleApp.scala
@@ -42,7 +42,7 @@ object ExampleApp {
   final case class BookingPatch(origin: Option[LatLon], destination: Option[LatLon])
 
   // #main
-  def apply(implicit createActorSystem: => ActorSystem[Nothing]): Resource[IO, Server] = {
+  def apply(createActorSystem: => ActorSystem[Nothing]): Resource[IO, Server] = {
     implicit val bookingCommandProtocol: BookingCommandProtocol = new BookingCommandProtocol
     implicit val vehicleCommandProtocol: VehicleCommandProtocol = new VehicleCommandProtocol
     implicit val eventApplier: BookingEventApplier = new BookingEventApplier
@@ -58,7 +58,7 @@ object ExampleApp {
       .eval(Slf4jLogger.create[IO])
       .flatMap { implicit logger: Logger[IO] =>
         AkkaCluster.managedResource[IO](createActorSystem).flatMap {
-          implicit cluster: AkkaCluster =>
+          implicit cluster: AkkaCluster[IO] =>
             Resource
               .both(
                 deployEntity[
@@ -98,7 +98,8 @@ object ExampleApp {
   // #api
   private def httpService(
       bookingRepository: BookingRepositoryAlg[IO],
-      vehicleRepository: VehicleRepositoryAlg[IO]
+      vehicleRepository: VehicleRepositoryAlg[IO],
+      akkaCluster: AkkaCluster[IO]
   ): HttpApp[IO] = HttpRoutes
     .of[IO] {
       case req @ POST -> Root / "booking"                => postBooking(bookingRepository, req)
@@ -114,6 +115,11 @@ object ExampleApp {
         setVehicleSpeed(vehicleRepository, id, req)
       case req @ POST -> Root / "vehicle" / UUIDVar(id) / "position" =>
         setVehiclePosition(vehicleRepository, id, req)
+      case GET -> Root / "health" =>
+        akkaCluster.isMemberUp.flatMap {
+          case true  => Ok("OK")
+          case false => ServiceUnavailable("Cluster member is down")
+        }
     }
     .orNotFound
   // #api

--- a/example/src/main/scala/endless/example/Main.scala
+++ b/example/src/main/scala/endless/example/Main.scala
@@ -8,18 +8,26 @@ import akka.persistence.testkit.{
 import cats.effect._
 import com.typesafe.config.ConfigFactory
 
+import scala.concurrent.ExecutionContext
+
 object Main extends IOApp {
-  implicit def actorSystem: ActorSystem[Nothing] =
+  def actorSystem(executionContext: ExecutionContext): ActorSystem[Nothing] =
     ActorSystem.wrap(
       akka.actor.ActorSystem(
-        "example-as",
-        PersistenceTestKitPlugin.config
-          .withFallback(PersistenceTestKitDurableStateStorePlugin.config)
-          .withFallback(ConfigFactory.defaultApplication)
-          .resolve()
+        name = "example-as",
+        config = Some(
+          PersistenceTestKitPlugin.config
+            .withFallback(PersistenceTestKitDurableStateStorePlugin.config)
+            .withFallback(ConfigFactory.defaultApplication)
+            .resolve()
+        ),
+        defaultExecutionContext = Some(executionContext),
+        classLoader = None
       )
     )
 
-  def run(args: List[String]): IO[ExitCode] = ExampleApp.apply.useForever.as(ExitCode.Success)
+  def run(args: List[String]): IO[ExitCode] = IO.executionContext
+    .map(actorSystem)
+    .flatMap(system => ExampleApp.apply(system).useForever.as(ExitCode.Success))
 
 }

--- a/example/src/test/scala/endless/example/ExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/ExampleAppSuite.scala
@@ -5,7 +5,7 @@ import akka.persistence.testkit.{
   PersistenceTestKitDurableStateStorePlugin,
   PersistenceTestKitPlugin
 }
-import cats.effect.IO
+import cats.effect.{IO, Resource}
 import cats.syntax.show._
 import com.typesafe.config.ConfigFactory
 import endless.example.ExampleApp._
@@ -21,21 +21,28 @@ import org.http4s.implicits._
 
 import java.time.Instant
 import java.util.UUID
+import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._
 
 class ExampleAppSuite extends munit.CatsEffectSuite {
-  implicit def actorSystem: ActorSystem[Nothing] =
+  private def actorSystem(executionContext: ExecutionContext): ActorSystem[Nothing] =
     ActorSystem.wrap(
       akka.actor.ActorSystem(
         "example-as",
-        PersistenceTestKitPlugin.config
-          .withFallback(PersistenceTestKitDurableStateStorePlugin.config)
-          .withFallback(ConfigFactory.defaultApplication)
-          .resolve()
+        config = Some(
+          PersistenceTestKitPlugin.config
+            .withFallback(PersistenceTestKitDurableStateStorePlugin.config)
+            .withFallback(ConfigFactory.defaultApplication)
+            .resolve()
+        ),
+        defaultExecutionContext = Some(executionContext)
       )
     )
 
-  private val server = ResourceSuiteLocalFixture("booking-server", ExampleApp.apply)
+  private val server = ResourceSuiteLocalFixture(
+    "booking-server",
+    Resource.eval(IO.executionContext).map(actorSystem).flatMap(system => ExampleApp.apply(system))
+  )
   private val client = ResourceSuiteLocalFixture("booking-client", BlazeClientBuilder[IO].resource)
   private val baseUri = uri"http://localhost:8080"
   private val baseBookingUri = baseUri / "booking"

--- a/example/src/test/scala/endless/example/ExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/ExampleAppSuite.scala
@@ -197,4 +197,8 @@ class ExampleAppSuite extends munit.CatsEffectSuite {
       400
     )
   }
+
+  test("GET health returns OK") {
+    assertIO(client().status(GET(baseUri / "health")).map(_.code), 200)
+  }
 }

--- a/runtime/src/main/resources/reference.conf
+++ b/runtime/src/main/resources/reference.conf
@@ -16,5 +16,5 @@ akka {
       "endless.runtime.akka.data.Reply" = akka-persistence-tagless-reply
     }
   }
-  coordinated-shutdown.run-by-jvm-shutdown-hook=off   // ensure we have control of cluster shutdown via resource scoping
+  akka.coordinated-shutdown.exit-jvm = on // ensure the JVM exits when the cluster decides to remove the node after a SBR decision
 }

--- a/runtime/src/main/scala/endless/runtime/akka/deploy/AkkaCluster.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/deploy/AkkaCluster.scala
@@ -1,52 +1,128 @@
 package endless.runtime.akka.deploy
 
+import akka.Done
 import akka.actor.CoordinatedShutdown
 import akka.actor.typed.ActorSystem
+import akka.cluster.{Cluster, MemberStatus}
 import akka.cluster.sharding.typed.scaladsl.ClusterSharding
-import cats.effect.kernel.{Async, Resource, Sync}
+import cats.effect.kernel.implicits._
+import cats.effect.kernel.{Async, Deferred, Resource, Sync}
+import cats.effect.std.Dispatcher
+import cats.implicits.catsSyntaxApplicativeError
 import cats.syntax.flatMap._
 import cats.syntax.functor._
-import cats.syntax.show._
 import org.typelevel.log4cats.Logger
 
-/** Actor system and cluster sharding extension.
+import scala.concurrent.TimeoutException
+import scala.concurrent.duration.{Duration, DurationInt}
+
+/** Actor system and cluster sharding extension as well as dispatcher tied to its resource scope.
   * @param system
   *   actor system
+  * @param cluster
+  *   cluster extension
   * @param sharding
   *   cluster sharding extension
+  * @param dispatcher
+  *   effects dispatcher tied to the cluster resource scope
   */
-final case class AkkaCluster(system: ActorSystem[_], sharding: ClusterSharding)
+final case class AkkaCluster[F[_]: Async](
+    system: ActorSystem[_],
+    dispatcher: Dispatcher[F],
+    cluster: Cluster,
+    sharding: ClusterSharding
+) {
+
+  /** Returns true if the cluster member is up. Can be used for readiness checks.
+    */
+  def isMemberUp: F[Boolean] = Sync[F].delay(cluster.selfMember.status match {
+    case MemberStatus.Up => true
+    case _               => false
+  })
+}
 
 object AkkaCluster {
 
   /** Create a resource that manages the lifetime of an Akka actor system with cluster sharding
     * extension. The actor system is created when the resource is acquired and shutdown when the
-    * resource is released. Akka's built-in SIGTERM hook is disabled in the reference config, so
-    * that CoordinatedShutdown is only triggered here, in the release action.
+    * resource is released.
+    *
+    * @see
+    *   Some elements borrowed from
+    *   https://alexn.org/blog/2023/04/17/integrating-akka-with-cats-effect-3/
+    *
+    * @param createActorSystem
+    *   Actor system creator. It is recommended to use the IO execution context
+    *   (`IO.executionContext`) for the actor system, as it supports Akka operation and it's simpler
+    *   to have a single application execution context
+    *
+    * @param catsEffectReleaseTimeout
+    *   Maximum amount of time Akka coordinated shutdown is allowed to wait for cats-effect to
+    *   finish, typically when Akka initiates shutdown following a SBR decision. Default (5 seconds)
+    *   is the same as the default-phase-timeout of Akka coordinated shutdown.
+    * @param akkaReleaseTimeout
+    *   Maximum amount of time to wait for the actor system to terminate during resource release (5
+    *   seconds by default).
     */
   def managedResource[F[_]: Async: Logger](
-      createActorSystem: => ActorSystem[_]
-  ): Resource[F, AkkaCluster] = Resource.make(initCluster(createActorSystem))(shutdownCluster[F])
-
-  private def initCluster[F[_]: Sync: Logger](
-      createActorSystem: => ActorSystem[_]
-  ): F[AkkaCluster] =
-    Logger[F].debug("Joining Akka actor cluster") >> Sync[F]
-      .delay {
-        val actorSystem = createActorSystem
-        val sharding = ClusterSharding(actorSystem)
-        AkkaCluster(actorSystem, sharding)
-      }
-      .flatTap(cluster =>
-        Logger[F].info(show"Joined Akka actor cluster with system name ${cluster.system.name}")
+      createActorSystem: => ActorSystem[_],
+      catsEffectReleaseTimeout: Duration = 5.seconds,
+      akkaReleaseTimeout: Duration = 5.seconds
+  ): Resource[F, AkkaCluster[F]] =
+    Dispatcher
+      .parallel(await = true)
+      .flatMap(dispatcher =>
+        Resource[F, AkkaCluster[F]](for {
+          cluster <- createCluster(createActorSystem, dispatcher)
+          awaitCatsTermination <- Deferred[F, Unit]
+          _ <- Sync[F].delay {
+            CoordinatedShutdown(cluster.system)
+              .addTask(CoordinatedShutdown.PhaseBeforeServiceUnbind, "ce-resources-release") { () =>
+                dispatcher.unsafeToFuture(
+                  awaitCatsTermination.get
+                    .timeout(catsEffectReleaseTimeout)
+                    .recoverWith { case ex: TimeoutException =>
+                      Logger[F].error(ex)(
+                        "Timed out during cluster shutdown while waiting for cats-effect resources release"
+                      )
+                    }
+                    .as(Done)
+                )
+              }
+          }
+        } yield {
+          val release = for {
+            _ <- awaitCatsTermination.complete(())
+            _ <- Logger[F].info("Leaving Akka actor cluster")
+            _ <- Async[F]
+              .fromFuture(
+                Async[F].blocking(
+                  CoordinatedShutdown(cluster.system)
+                    .run(CoordinatedShutdown.ActorSystemTerminateReason)
+                )
+              )
+              .void
+              .timeoutAndForget(akkaReleaseTimeout)
+              .handleErrorWith(
+                Logger[F].error(_)(
+                  "Timed out during cluster shutdown while waiting for actor system to terminate"
+                )
+              )
+            _ <- Logger[F].info("Akka cluster exited and actor system shutdown complete")
+          } yield ()
+          (cluster, release)
+        })
       )
 
-  private def shutdownCluster[F[_]: Async: Logger](cluster: AkkaCluster) =
-    Logger[F].info("Leaving Akka actor cluster") >> Async[F]
-      .fromFuture(
-        Async[F].delay(
-          CoordinatedShutdown(cluster.system).run(CoordinatedShutdown.ActorSystemTerminateReason)
-        )
-      )
-      .void >> Logger[F].info("Akka cluster exited and actor system shutdown complete")
+  private def createCluster[F[_]: Async: Logger](
+      createActorSystem: => ActorSystem[_],
+      dispatcher: Dispatcher[F]
+  ) = for {
+    system <- Sync[F].delay(createActorSystem)
+    _ <- Logger[F].info(s"Created actor system ${system.name}")
+    cluster <- Sync[F].delay(Cluster(system))
+    _ <- Logger[F].info(s"Created cluster extension for actor system ${system.name}")
+    sharding <- Sync[F].delay(ClusterSharding(system))
+    _ <- Logger[F].info(s"Created cluster sharding extension for actor system ${system.name}")
+  } yield AkkaCluster(system, dispatcher, cluster, sharding)
 }

--- a/runtime/src/main/scala/endless/runtime/akka/deploy/Deployer.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/deploy/Deployer.scala
@@ -114,7 +114,7 @@ trait Deployer {
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]] =
         identity
   )(implicit
-      akkaCluster: AkkaCluster,
+      akkaCluster: AkkaCluster[F],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
       eventApplier: EventApplier[S, E],
@@ -151,7 +151,7 @@ trait Deployer {
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]] =
         identity
   )(implicit
-      akkaCluster: AkkaCluster,
+      akkaCluster: AkkaCluster[F],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
       eventApplier: EventApplier[S, E],
@@ -175,7 +175,7 @@ trait Deployer {
         Command
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]]
   )(implicit
-      akkaCluster: AkkaCluster,
+      akkaCluster: AkkaCluster[F],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
       eventApplier: EventApplier[S, E],

--- a/runtime/src/main/scala/endless/runtime/akka/deploy/DurableDeployer.scala
+++ b/runtime/src/main/scala/endless/runtime/akka/deploy/DurableDeployer.scala
@@ -112,7 +112,7 @@ trait DurableDeployer {
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]] =
         identity
   )(implicit
-      akkaCluster: AkkaCluster,
+      akkaCluster: AkkaCluster[F],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
       askTimeout: Timeout
@@ -147,7 +147,7 @@ trait DurableDeployer {
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]] =
         identity
   )(implicit
-      akkaCluster: AkkaCluster,
+      akkaCluster: AkkaCluster[F],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
       askTimeout: Timeout
@@ -168,7 +168,7 @@ trait DurableDeployer {
         Command
       ]] => akka.cluster.sharding.typed.scaladsl.Entity[Command, ShardingEnvelope[Command]]
   )(implicit
-      akkaCluster: AkkaCluster,
+      akkaCluster: AkkaCluster[F],
       nameProvider: EntityNameProvider[ID],
       commandProtocol: CommandProtocol[Alg],
       askTimeout: Timeout


### PR DESCRIPTION
The SBR can decide that the node needs to exit, in which case Akka initiates the application shutdown. We need to make sure that all cats-effect resources are released in such cases. This PR improves mechanisms around application shutdown.