### PR TITLE
Improve documentation for `catsEffectReleaseTimeout`

### DIFF
--- a/akka-runtime/src/main/resources/reference.conf
+++ b/akka-runtime/src/main/resources/reference.conf
@@ -16,5 +16,5 @@ akka {
       "endless.runtime.akka.data.Reply" = akka-persistence-tagless-reply
     }
   }
-  akka.coordinated-shutdown.exit-jvm = on // ensure the JVM exits when the cluster decides to remove the node after a SBR decision
+  coordinated-shutdown.exit-jvm = on // ensure the JVM exits when the cluster decides to remove the node after a SBR decision
 }

--- a/akka-runtime/src/main/scala/endless/runtime/akka/deploy/AkkaCluster.scala
+++ b/akka-runtime/src/main/scala/endless/runtime/akka/deploy/AkkaCluster.scala
@@ -58,8 +58,12 @@ object AkkaCluster {
     *
     * @param catsEffectReleaseTimeout
     *   Maximum amount of time Akka coordinated shutdown is allowed to wait for cats-effect to
-    *   finish, typically when Akka initiates shutdown following a SBR decision. Default (5 seconds)
-    *   is the same as the default-phase-timeout of Akka coordinated shutdown.
+    *   finish, typically when Akka initiates shutdown following a SBR decision. This value should
+    *   not be higher than the actual timeout for `before-service-unbind` phase of Akka coordinated
+    *   shutdown. See <a href="https://doc.akka.io/docs/akka/current/coordinated-shutdown.html">Akka
+    *   coordinated shutdown documentation</a> to learn how to configure the timeouts of individual
+    *   phases. Default (5 seconds) is the same as the default-phase-timeout of Akka coordinated
+    *   shutdown.
     * @param akkaReleaseTimeout
     *   Maximum amount of time to wait for the actor system to terminate during resource release (5
     *   seconds by default).

--- a/pekko-runtime/src/main/resources/reference.conf
+++ b/pekko-runtime/src/main/resources/reference.conf
@@ -16,5 +16,5 @@ pekko {
       "endless.runtime.pekko.data.Reply" = pekko-persistence-tagless-reply
     }
   }
-  pekko.coordinated-shutdown.exit-jvm = on // ensure the JVM exits when the cluster decides to remove the node after a SBR decision
+  coordinated-shutdown.exit-jvm = on // ensure the JVM exits when the cluster decides to remove the node after a SBR decision
 }

--- a/pekko-runtime/src/main/scala/endless/runtime/pekko/ShardingCommandSender.scala
+++ b/pekko-runtime/src/main/scala/endless/runtime/pekko/ShardingCommandSender.scala
@@ -12,14 +12,14 @@ import endless.core.protocol.{CommandSender, EntityIDEncoder, OutgoingCommand}
 import endless.runtime.pekko.data.{Command, Reply}
 import org.typelevel.log4cats.Logger
 
-/** Implementation of [[CommandSender]] for pekko cluster sharding
+/** Implementation of [[CommandSender]] for Pekko cluster sharding
   *
   * Retrieves the entity ref and asks the command, then decodes the reply and lifts it into `F`
   *
   * @param sharding
-  *   pekko cluster sharding extension
+  *   Pekko cluster sharding extension
   * @param askTimeout
-  *   pekko ask timeout
+  *   Pekko ask timeout
   * @param idEncoder
   *   entity ID encoder
   * @param nameProvider

--- a/pekko-runtime/src/main/scala/endless/runtime/pekko/deploy/PekkoCluster.scala
+++ b/pekko-runtime/src/main/scala/endless/runtime/pekko/deploy/PekkoCluster.scala
@@ -43,20 +43,20 @@ final case class PekkoCluster[F[_]: Async](
 
 object PekkoCluster {
 
-  /** Create a resource that manages the lifetime of an pekko actor system with cluster sharding
+  /** Create a resource that manages the lifetime of an Pekko actor system with cluster sharding
     * extension. The actor system is created when the resource is acquired and shutdown when the
     * resource is released.
     *
     * @param createActorSystem
     *   Actor system creator. It is recommended to use the IO execution context
-    *   (`IO.executionContext`) for the actor system, as it supports pekko operation and it's
+    *   (`IO.executionContext`) for the actor system, as it supports Pekko operation and it's
     *   simpler to have a single application execution context
     * @param catsEffectReleaseTimeout
-    *   Maximum amount of time pekko coordinated shutdown is allowed to wait for cats-effect to
-    *   finish, typically when pekko initiates shutdown following a SBR decision. This value should
-    *   not be higher than the actual timeout for `before-service-unbind` phase of pekko coordinated
+    *   Maximum amount of time Pekko coordinated shutdown is allowed to wait for cats-effect to
+    *   finish, typically when Pekko initiates shutdown following a SBR decision. This value should
+    *   not be higher than the actual timeout for `before-service-unbind` phase of Pekko coordinated
     *   shutdown. See <a
-    *   href="https://pekko.apache.org/docs/pekko/current/coordinated-shutdown.html">pekko
+    *   href="https://pekko.apache.org/docs/pekko/current/coordinated-shutdown.html">Pekko
     *   coordinated shutdown documentation</a> to learn how to configure the timeouts of individual
     *   phases. Default (5 seconds) is the same as the default-phase-timeout of Pekko coordinated
     *   shutdown.
@@ -93,7 +93,7 @@ object PekkoCluster {
         } yield {
           val release = for {
             _ <- awaitCatsTermination.complete(())
-            _ <- Logger[F].info("Leaving pekko actor cluster")
+            _ <- Logger[F].info("Leaving Pekko actor cluster")
             _ <- Async[F]
               .fromFuture(
                 Async[F].blocking(

--- a/pekko-runtime/src/main/scala/endless/runtime/pekko/deploy/PekkoCluster.scala
+++ b/pekko-runtime/src/main/scala/endless/runtime/pekko/deploy/PekkoCluster.scala
@@ -51,11 +51,15 @@ object PekkoCluster {
     *   Actor system creator. It is recommended to use the IO execution context
     *   (`IO.executionContext`) for the actor system, as it supports pekko operation and it's
     *   simpler to have a single application execution context
-    *
     * @param catsEffectReleaseTimeout
     *   Maximum amount of time pekko coordinated shutdown is allowed to wait for cats-effect to
-    *   finish, typically when pekko initiates shutdown following a SBR decision. Default (5
-    *   seconds) is the same as the default-phase-timeout of pekko coordinated shutdown.
+    *   finish, typically when pekko initiates shutdown following a SBR decision. This value should
+    *   not be higher than the actual timeout for `before-service-unbind` phase of pekko coordinated
+    *   shutdown. See <a
+    *   href="https://pekko.apache.org/docs/pekko/current/coordinated-shutdown.html">pekko
+    *   coordinated shutdown documentation</a> to learn how to configure the timeouts of individual
+    *   phases. Default (5 seconds) is the same as the default-phase-timeout of Pekko coordinated
+    *   shutdown.
     * @param pekkoReleaseTimeout
     *   Maximum amount of time to wait for the actor system to terminate during resource release (5
     *   seconds by default).


### PR DESCRIPTION
The `catsEffectReleaseTimeout` is applicable to the Akka/Pekko coordinated shutdown task, which is added to a specific phase. The phase timeout is configured separately via config files of Akka/Pekko. The timeout of a single task should not be higher than the timeout of the related phase.

Plus some minor fixes.