### PR TITLE
Side effect mode

### DIFF
--- a/akka-runtime/src/test/scala/endless/runtime/akka/protobuf/ScalaPbSerializerSuite.scala
+++ b/akka-runtime/src/test/scala/endless/runtime/akka/protobuf/ScalaPbSerializerSuite.scala
@@ -56,6 +56,7 @@ object ScalaPbSerializerSuite {
       |      "endless.runtime.akka.protobuf.ScalaPbSerializer" = 1111
       |    }
       |  }
+      |  coordinated-shutdown.exit-jvm = off
       |}
     """.stripMargin
 }

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ lazy val pekkoRuntime = (project in file("pekko-runtime"))
   .settings(commonSettings *)
   .dependsOn(core)
   .settings(
-    libraryDependencies ++= catsEffectStd ++ pekkoProvided ++ log4cats ++ scalapbCustomizations ++ (mUnit ++ logback ++ log4catsSlf4j :+ pekkoTypedTestkit % pekkoVersion)
+    libraryDependencies ++= catsEffectStd ++ pekkoProvided ++ log4cats ++ scalapbCustomizations ++ (mUnit ++ logback :+ pekkoTypedTestkit % pekkoVersion)
       .map(_ % Test)
   )
   .settings(
@@ -136,7 +136,7 @@ lazy val example = (project in file("example"))
   .settings(commonSettings *)
   .dependsOn(core, akkaRuntime, pekkoRuntime, circeHelpers, protobufHelpers)
   .settings(
-    libraryDependencies ++= catsEffect ++ http4s ++ blaze ++ akka ++ pekko ++ scalapbCustomizations ++ akkaTest ++ pekkoTest ++ logback ++ log4catsSlf4j ++ (mUnit ++ catsEffectMUnit ++ scalacheckEffect ++ log4catsTesting)
+    libraryDependencies ++= catsEffect ++ http4s ++ blaze ++ akka ++ pekko ++ scalapbCustomizations ++ akkaTest ++ pekkoTest ++ logback ++ (mUnit ++ catsEffectMUnit ++ scalacheckEffect ++ log4catsTesting)
       .map(_ % Test)
   )
   .settings(name := "endless-example", run / fork := true, publish / skip := true)

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ import Dependencies.*
 import sbtversionpolicy.Compatibility.None
 
 val scala213 = "2.13.14"
-val scala3 = "3.4.2"
+val scala3 = "3.4.3"
 
 val commonSettings = Seq(
   wartremoverExcluded += sourceManaged.value,

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import Dependencies.*
 import sbtversionpolicy.Compatibility.None
 
-val scala213 = "2.13.12"
+val scala213 = "2.13.14"
 val scala3 = "3.4.2"
 
 val commonSettings = Seq(
@@ -88,7 +88,7 @@ lazy val pekkoRuntime = (project in file("pekko-runtime"))
   .settings(commonSettings *)
   .dependsOn(core)
   .settings(
-    libraryDependencies ++= catsEffectStd ++ pekkoProvided ++ log4cats ++ scalapbCustomizations ++ (mUnit :+ pekkoTypedTestkit % pekkoVersion)
+    libraryDependencies ++= catsEffectStd ++ pekkoProvided ++ log4cats ++ scalapbCustomizations ++ (mUnit ++ logback ++ log4catsSlf4j :+ pekkoTypedTestkit % pekkoVersion)
       .map(_ % Test)
   )
   .settings(

--- a/core/src/main/scala/endless/core/entity/Deployer.scala
+++ b/core/src/main/scala/endless/core/entity/Deployer.scala
@@ -43,8 +43,9 @@ trait Deployer {
     *     the message is decoded and run with the provided `behavior` interpreter: this typically
     *     involves reading the entity state (e.g. for validation), and writing events (which can
     *     lead to a new version of the state via the `eventApplier` function)
-    *   - after events are written, a possible side-effect is triggered: this can be asynchronous
-    *     (i.e. the function doesn't wait for completion of the side-effect to return)
+    *   - after events are written, a possible side-effect is triggered: this is by default
+    *     asynchronous (i.e. the function doesn't wait for completion of the side-effect to return)
+    *     but can be made synchronous by overriding the `runModeFor` method in the `SideEffect`
     *   - the function finally returns to the caller with the result of the operation described by
     *     the entity algebra (reply value, typically encoded over the wire in a distributed
     *     deployment)

--- a/core/src/main/scala/endless/core/entity/DurableDeployer.scala
+++ b/core/src/main/scala/endless/core/entity/DurableDeployer.scala
@@ -47,7 +47,8 @@ trait DurableDeployer {
     *     involves reading the entity state (e.g. for validation), and writing events (which can
     *     lead to a new version of the state via the `eventApplier` function)
     *   - after events were written, a possible side-effect is triggered: this can be asynchronous
-    *     (i.e. the function doesn't wait for completion of the side-effect to return)
+    *     (i.e. the function doesn't wait for completion of the side-effect to return) but can be
+    *     made synchronous by overriding the `runModeFor` method in the `SideEffect`
     *   - the function finally returns to the caller with the result of the operation described by
     *     the entity algebra (reply value, typically encoded over the wire in a distributed
     *     deployment)
@@ -60,7 +61,7 @@ trait DurableDeployer {
     * algebras respectively (both higher-kinded type constructors).
     *
     * Since the behavior described above involves concurrent handling of repository interactions and
-    * asynchronous side-effecting, we expect `Async` from `F`.
+    * possible asynchronous side-effecting, we expect `Async` from `F`.
     *
     * `EntityIDCodec` is used to encode/decode entity IDs to/from strings.
     *

--- a/core/src/main/scala/endless/core/entity/SideEffect.scala
+++ b/core/src/main/scala/endless/core/entity/SideEffect.scala
@@ -1,10 +1,13 @@
 package endless.core.entity
+import cats.Applicative
+import cats.kernel.Eq
 import cats.syntax.eq.*
 
 /** `SideEffect[F, S, Alg]` represents a side-effect applied in context `F`. The side-effect is
-  * triggered just after events persistence if any, or after some reads for a read-only command. Its
-  * is interpreted with `Async` in order to allow for asynchronous processes. The passed `Effector`
-  * can be used to access entity state and algebra and to control passivation.
+  * triggered just after events persistence if any, or after some reads for a read-only command. The
+  * mode of interpretation is determined by the `runModeFor` method, which defaults to `Async` but
+  * can be overridden. The passed `Effector` can be used to access entity state and algebra and to
+  * control passivation.
   * @tparam F
   *   effect type
   * @tparam S
@@ -14,9 +17,15 @@ import cats.syntax.eq.*
   */
 trait SideEffect[F[_], S, Alg[_[_]]] {
   def apply(trigger: SideEffect.Trigger, effector: Effector[F, S, Alg]): F[Unit]
+
+  def runModeFor(trigger: SideEffect.Trigger, state: Option[S])(implicit
+      applicative: Applicative[F]
+  ): F[SideEffect.RunMode] = Applicative[F].pure(SideEffect.RunMode.Async)
 }
 
 object SideEffect {
+  def unit[F[_]: Applicative, S, Alg[_[_]]]: SideEffect[F, S, Alg] =
+    (_: Trigger, _: Effector[F, S, Alg]) => Applicative[F].unit
 
   /** Trigger for the invocation of a side-effect: this allows for differentiated behavior depending
     * on the context in which the side-effect is triggered.
@@ -39,6 +48,30 @@ object SideEffect {
     /** Triggered just after recovery */
     case object AfterRecovery extends Trigger
 
-    implicit val eqTrigger: cats.Eq[Trigger] = cats.Eq.fromUniversalEquals
+    implicit val eqTrigger: Eq[Trigger] = Eq.fromUniversalEquals
+  }
+
+  /** Run mode for a side-effect: `Async` (default value) means that the side-effect is triggered in
+    * "fire & forget" mode, while `Sync` means it is run to completion before any other command is
+    * processed by the entity.
+    */
+  sealed trait RunMode
+  object RunMode {
+
+    /** Run to completion before any other command is processed by the entity.
+      *
+      * @note
+      *   This mode should in most cases not be used for long-running side-effects, as it can hurt
+      *   availability of the entity for command processing.
+      */
+    case object Sync extends RunMode
+
+    /** Run in "fire & forget" mode.
+      *
+      * @note
+      *   This mode requires careful consideration of the side-effect's concurrency and idempotency,
+      *   as there is no limit on the number of invocations running simultaneously at any one time.
+      */
+    case object Async extends RunMode
   }
 }

--- a/core/src/main/scala/endless/core/interpret/EntityRunFunctions.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityRunFunctions.scala
@@ -1,6 +1,5 @@
 package endless.core.interpret
 
-import cats.conversions.all.*
 import cats.data.{Chain, NonEmptyChain}
 import cats.syntax.applicative.*
 import cats.syntax.either.*

--- a/core/src/main/scala/endless/core/interpret/EntityT.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityT.scala
@@ -1,6 +1,5 @@
 package endless.core.interpret
 
-import cats.conversions.all.*
 import cats.data.{Chain, NonEmptyChain}
 import cats.effect.kernel.Clock
 import cats.syntax.applicative.*

--- a/core/src/main/scala/endless/core/interpret/EntityTLiftInstance.scala
+++ b/core/src/main/scala/endless/core/interpret/EntityTLiftInstance.scala
@@ -1,7 +1,6 @@
 package endless.core.interpret
 
 import cats.Monad
-import cats.conversions.all.*
 import cats.data.NonEmptyChain
 import cats.syntax.applicative.*
 import cats.syntax.either.*

--- a/core/src/main/scala/endless/core/interpret/SideEffectInterpreter.scala
+++ b/core/src/main/scala/endless/core/interpret/SideEffectInterpreter.scala
@@ -56,5 +56,5 @@ object SideEffectInterpreter {
     */
   def unit[F[_]: Applicative, S, Alg[_[_]], RepositoryAlg[_[_]]]
       : SideEffectInterpreter[F, S, Alg, RepositoryAlg] =
-    lift((_, _) => (_, _) => Applicative[F].unit)
+    lift((_, _) => SideEffect.unit[F, S, Alg])
 }

--- a/core/src/test/scala/endless/core/interpret/DurableEntityTSuite.scala
+++ b/core/src/test/scala/endless/core/interpret/DurableEntityTSuite.scala
@@ -46,7 +46,7 @@ class DurableEntityTSuite extends DisciplineSuite {
       F: Arbitrary[F[A]]
   ): Arbitrary[DurableEntityT[F, SampleState, A]] = Arbitrary(
     F.arbitrary.map(
-      DurableEntityT.stateWriter(sampleState)(Applicative[F]) >> DurableEntityT.liftF(_)
+      DurableEntityT.stateWriter(sampleState)(using Applicative[F]) >> DurableEntityT.liftF(_)
     )
   )
 

--- a/core/src/test/scala/endless/core/interpret/EntityTSuite.scala
+++ b/core/src/test/scala/endless/core/interpret/EntityTSuite.scala
@@ -54,7 +54,7 @@ class EntityTSuite extends DisciplineSuite {
   checkAll(
     "EntityT.FunctorLaws for direct map def",
     FunctorTests[EntityT[ListWrapper, State, Event, *]](
-      new Functor[EntityT[ListWrapper, State, Event, *]] {
+      using new Functor[EntityT[ListWrapper, State, Event, *]] {
         override def map[A, B](fa: EntityT[ListWrapper, State, Event, A])(
             f: A => B
         ): EntityT[ListWrapper, State, Event, B] = fa.map(f)

--- a/documentation/src/main/paradox/side-effect.md
+++ b/documentation/src/main/paradox/side-effect.md
@@ -3,6 +3,8 @@
 ```scala
 trait SideEffect[F[_], S, Alg[_[_]]] {
   def apply(trigger: SideEffect.Trigger, effector: Effector[F, S, Alg]): F[Unit]
+
+  def runModeFor(trigger: SideEffect.Trigger, state: Option[S]): F[SideEffect.RunMode] 
 }
 ```
 
@@ -14,7 +16,9 @@ trait SideEffect[F[_], S, Alg[_[_]]] {
 
 It represents a side-effect that is triggered according to `trigger` either after event persistence, command handling (for a read-only behavior invocation) or recovery. Side-effects are typically asynchronous operations such as kafka writes, outgoing REST requests, and [entity passivation](https://doc.akka.io/docs/akka/current/typed/cluster-sharding.html#passivation) (flushing out of memory).  
 
-In the runtime, the resulting `F[Unit]` is interpreted with `Async` in *run & forget* mode so that command reply is not delayed by any lengthy side-effect. The passed @ref:[Effector](effector.md) instance can be used to access entity state, chain further interactions with the entity itself and to control passivation (for an example, see @github[BookingEffector](/example/src/main/scala/endless/example/logic/BookingSideEffect.scala)
+In the runtime, the resulting `F[Unit]` is interpreted according to the `RunMode` setting indicated by a preliminary call to `runModeFor`. With `Async` mode, it triggers in *run & forget* mode so that command reply is not delayed by any lengthy side-effect. With `Async` mode, it triggers in *run & forget* mode so that any lengthy side-effect does not delay command reply. With `Sync` mode, the side-effect runs to completion before the entity processes the next command: this can simplify the side-effect logic as it precludes accounting for concurrency, but can hurt the system's responsiveness. The default implementation of `runModeFor` sets it to `Async`.
+
+The passed @ref:[Effector](effector.md) instance can be used to access entity state, chain further interactions with the entity itself and to control passivation (for an example, see @github[BookingEffector](/example/src/main/scala/endless/example/logic/BookingSideEffect.scala)
 
 @@@ note
 Defining a side-effect is entirely optional, pass-in `SideEffectInterpreter.unit` in @scaladoc[deployRepository](endless.runtime.akka.deploy.Deployer) if there are no side-effects to describe.

--- a/example/src/main/resources/akka.conf
+++ b/example/src/main/resources/akka.conf
@@ -39,4 +39,6 @@ akka {
       passivate-idle-entity-after = off
     }
   }
+
+  coordinated-shutdown.exit-jvm = off
 }

--- a/example/src/main/resources/pekko.conf
+++ b/example/src/main/resources/pekko.conf
@@ -39,4 +39,6 @@ pekko {
       passivate-idle-entity-after = off
     }
   }
+
+  coordinated-shutdown.exit-jvm = off
 }

--- a/example/src/main/scala/endless/example/logic/BookingSideEffect.scala
+++ b/example/src/main/scala/endless/example/logic/BookingSideEffect.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration.*
 class BookingSideEffect[F[_]: Logger: Monad]()(implicit
     availabilityAlg: AvailabilityAlg[F]
 ) extends SideEffect[F, Booking, BookingAlg] {
+
   def apply(trigger: Trigger, effector: Effector[F, Booking, BookingAlg]): F[Unit] = {
     import effector.*
 

--- a/example/src/main/scala/endless/example/protocol/BookingCommandProtocol.scala
+++ b/example/src/main/scala/endless/example/protocol/BookingCommandProtocol.scala
@@ -1,6 +1,5 @@
 package endless.example.protocol
 
-import cats.conversions.all.*
 import cats.syntax.show.*
 import com.google.protobuf.timestamp.Timestamp
 import endless.\/

--- a/example/src/test/scala/endless/example/AkkaExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/AkkaExampleAppSuite.scala
@@ -1,9 +1,10 @@
 package endless.example
 
 import endless.example.app.akka.AkkaApp
+import munit.AnyFixture
 
 class AkkaExampleAppSuite extends munit.CatsEffectSuite with ExampleAppSuite {
   lazy val port: Int = 8080
   private val akkaServer = ResourceSuiteLocalFixture("akka-server", AkkaApp(port))
-  override def munitFixtures: Seq[Fixture[?]] = List(akkaServer, client)
+  override def munitFixtures: Seq[AnyFixture[?]] = List(akkaServer, client)
 }

--- a/example/src/test/scala/endless/example/ExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/ExampleAppSuite.scala
@@ -7,6 +7,7 @@ import endless.example.data.Booking.BookingID
 import endless.example.data.Vehicle.VehicleID
 import endless.example.data.{Booking, LatLon, Speed}
 import io.circe.generic.auto.*
+import munit.catseffect.IOFixture
 import org.http4s.Method.*
 import org.http4s.Uri
 import org.http4s.blaze.client.BlazeClientBuilder
@@ -19,7 +20,7 @@ import java.util.UUID
 import scala.concurrent.duration.*
 
 trait ExampleAppSuite { self: munit.CatsEffectSuite =>
-  protected val client: Fixture[Client[IO]] =
+  protected val client: IOFixture[Client[IO]] =
     ResourceSuiteLocalFixture("booking-client", BlazeClientBuilder[IO].resource)
   def port: Int
   private lazy val baseUri = Uri.unsafeFromString(s"http://localhost:$port")

--- a/example/src/test/scala/endless/example/PekkoExampleAppSuite.scala
+++ b/example/src/test/scala/endless/example/PekkoExampleAppSuite.scala
@@ -1,9 +1,10 @@
 package endless.example
 
 import endless.example.app.pekko.PekkoApp
+import munit.AnyFixture
 
 class PekkoExampleAppSuite extends munit.CatsEffectSuite with ExampleAppSuite {
   lazy val port: Int = 8081
   private val pekkoServer = ResourceSuiteLocalFixture("pekko-server", PekkoApp(port))
-  override def munitFixtures: Seq[Fixture[?]] = List(pekkoServer, client)
+  override def munitFixtures: Seq[AnyFixture[?]] = List(pekkoServer, client)
 }

--- a/pekko-runtime/src/main/scala/endless/runtime/pekko/deploy/internal/DurableShardedEntityDeployer.scala
+++ b/pekko-runtime/src/main/scala/endless/runtime/pekko/deploy/internal/DurableShardedEntityDeployer.scala
@@ -13,6 +13,7 @@ import cats.syntax.flatMap.*
 import cats.syntax.functor.*
 import cats.syntax.show.*
 import endless.core.entity.*
+import endless.core.entity.SideEffect.RunMode
 import endless.core.interpret.DurableEntityT.{DurableEntityT, State}
 import endless.core.interpret.*
 import endless.core.protocol.{CommandProtocol, CommandSender, EntityIDCodec}
@@ -56,11 +57,11 @@ private[deploy] class DurableShardedEntityDeployer[F[_]: Async: Logger, S, ID: E
         )
         .receiveSignal {
           case (state, RecoveryCompleted) =>
-            dispatcher.unsafeRunAndForget(
-              Logger[F].info(
-                show"Recovery of ${nameProvider()} entity ${context.entityId} completed"
-              ) >> handleSideEffect(state, SideEffect.Trigger.AfterRecovery)
+            dispatcher.unsafeRunSync(
+              Logger[F]
+                .info(show"Recovery of ${nameProvider()} entity ${context.entityId} completed")
             )
+            handleSideEffect(state, SideEffect.Trigger.AfterRecovery)
           case (_, RecoveryFailed(failure)) =>
             dispatcher.unsafeRunSync(
               Logger[F].warn(
@@ -71,17 +72,25 @@ private[deploy] class DurableShardedEntityDeployer[F[_]: Async: Logger, S, ID: E
     )
   }
 
-  private def handleSideEffect(state: Option[S], trigger: SideEffect.Trigger)(implicit
+  private def handleSideEffect(
+      state: Option[S],
+      trigger: SideEffect.Trigger
+  )(implicit
       sideEffect: SideEffect[F, S, Alg],
       entity: Alg[F],
-      passivator: EntityPassivator[F]
-  ) = {
-    for {
+      passivator: EntityPassivator[F],
+      dispatcher: Dispatcher[F]
+  ): Unit = {
+    val effect = for {
       effector <- Effector[F, S, Alg](entity, state)
       _ <- sideEffect.apply(trigger, effector)
       passivationState <- effector.passivationState
       _ <- passivator.apply(passivationState)
     } yield ()
+    dispatcher.unsafeRunSync(sideEffect.runModeFor(trigger, state)) match {
+      case RunMode.Sync  => dispatcher.unsafeRunSync(effect)
+      case RunMode.Async => dispatcher.unsafeRunAndForget(effect)
+    }
   }
 
   private def handleCommand(state: Option[S], command: Command)(implicit
@@ -107,18 +116,14 @@ private[deploy] class DurableShardedEntityDeployer[F[_]: Async: Logger, S, ID: E
           case State.Updated(state) => Effect.persist(Option(state))
         })
           .thenRun((state: Option[S]) =>
-            // run the effector asynchronously, as it can describe long-running processes
-            dispatcher
-              .unsafeRunAndForget(
-                handleSideEffect(
-                  state,
-                  outcome match {
-                    case State.None        => SideEffect.Trigger.AfterRead
-                    case State.Existing(_) => SideEffect.Trigger.AfterRead
-                    case State.Updated(_)  => SideEffect.Trigger.AfterPersistence
-                  }
-                )
-              )
+            handleSideEffect(
+              state,
+              outcome match {
+                case State.None        => SideEffect.Trigger.AfterRead
+                case State.Existing(_) => SideEffect.Trigger.AfterRead
+                case State.Updated(_)  => SideEffect.Trigger.AfterPersistence
+              }
+            )
           )
           .thenReply(command.replyTo) { (_: Option[S]) =>
             Reply(incomingCommand.replyEncoder.encode(reply))

--- a/pekko-runtime/src/test/scala/endless/runtime/pekko/protobuf/ScalaPbSerializerSuite.scala
+++ b/pekko-runtime/src/test/scala/endless/runtime/pekko/protobuf/ScalaPbSerializerSuite.scala
@@ -41,8 +41,8 @@ object ScalaPbSerializerSuite {
   val serializationConfig: String =
     """
       |pekko {
-      |  provider = local
       |  actor {
+      |    provider = local
       |    serializers {
       |      scalapb = "endless.runtime.pekko.protobuf.ScalaPbSerializer"
       |    }
@@ -55,6 +55,7 @@ object ScalaPbSerializerSuite {
       |      "endless.runtime.pekko.protobuf.ScalaPbSerializer" = 1111
       |    }
       |  }
+      |  coordinated-shutdown.exit-jvm = off
       |}
     """.stripMargin
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -84,17 +84,20 @@ object Dependencies {
   )
   lazy val log4catsTesting = Seq("org.typelevel" %% "log4cats-testing" % log4catsVersion)
 
-  lazy val mUnitVersion = "1.0.0"
+  lazy val mUnitVersion = "1.0.1"
   lazy val disciplineMUnitVersion = "2.0.0"
+  lazy val mUnitScalacheckVersion = "1.0.0"
   lazy val mUnit =
-    Seq("org.scalameta" %% "munit", "org.scalameta" %% "munit-scalacheck").map(
-      _ % mUnitVersion
-    ) ++ Seq("org.typelevel" %% "discipline-munit" % disciplineMUnitVersion)
+    Seq(
+      "org.scalameta" %% "munit" % mUnitVersion,
+      "org.scalameta" %% "munit-scalacheck" % mUnitScalacheckVersion,
+      "org.typelevel" %% "discipline-munit" % disciplineMUnitVersion
+    )
 
   lazy val catsEffectMUnitVersion = "2.0.0"
   lazy val catsEffectMUnit = Seq("org.typelevel" %% "munit-cats-effect" % catsEffectMUnitVersion)
 
-  lazy val scalacheckEffectVersion = "1.0.4"
+  lazy val scalacheckEffectVersion = "2.0.0-M2"
   lazy val scalacheckEffect = Seq(
     "org.typelevel" %% "scalacheck-effect-munit" % scalacheckEffectVersion
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -79,9 +79,6 @@ object Dependencies {
 
   lazy val log4catsVersion = "2.7.0"
   lazy val log4cats = Seq("org.typelevel" %% "log4cats-core" % log4catsVersion)
-  lazy val log4catsSlf4j = Seq(
-    "org.typelevel" %% "log4cats-slf4j" % log4catsVersion
-  )
   lazy val log4catsTesting = Seq("org.typelevel" %% "log4cats-testing" % log4catsVersion)
 
   lazy val mUnitVersion = "1.0.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.9
+sbt.version=1.10.1

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.1.8")
+addSbtPlugin("org.wartremover" % "sbt-wartremover" % "3.2.0")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "2.1.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-version-policy" % "3.2.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.6.1")

--- a/scodec/src/test/scala/endless/scodec/ScodecCommandProtocolSuite.scala
+++ b/scodec/src/test/scala/endless/scodec/ScodecCommandProtocolSuite.scala
@@ -15,10 +15,12 @@ class ScodecCommandProtocolSuite extends munit.ScalaCheckSuite {
   }
 
   val dummyProtocol = new ScodecCommandProtocol[String, DummyAlg] {
-    def server[F[_]]: Decoder[IncomingCommand[F, DummyAlg]] =
-      ScodecDecoder(DummyCommand.scodecDecoder).map { case DummyCommand(x, y) =>
+    def server[F[_]]: Decoder[IncomingCommand[F, DummyAlg]] = {
+      implicit val decoder = DummyCommand.scodecDecoder
+      ScodecDecoder.apply.map { case DummyCommand(x, y) =>
         handleCommand[F, Boolean](_.dummy(x, y))
       }
+    }
 
     def clientFor[F[_]](id: ID)(implicit sender: CommandSender[F, ID]): DummyAlg[F] =
       (x: Int, y: String) => sendCommand[F, DummyCommand, Boolean](id, DummyCommand(x, y))


### PR DESCRIPTION
A new `runModeFor` method is introduced in `SideEffect`, with the default set to `Async` to ensure backward compatibility. With `Async` mode, it triggers in *run & forget* mode so that any lengthy side-effect does not delay command reply. With `Sync` mode, the side-effect runs to completion before the entity processes the next command: this can simplify the side-effect logic as it precludes accounting for concurrency, but can hurt the system's responsiveness.